### PR TITLE
Improve silo

### DIFF
--- a/silo/main.py
+++ b/silo/main.py
@@ -50,22 +50,14 @@ def fetch_high_risk_silo_positions(subgraph_id):
         try:
             response = run_query(query, variables, subgraph_id)
             if 'errors' in response:
-                print(f"GraphQL errors: {json.dumps(response['errors'], indent=2)}")
-                break
-            if 'data' not in response:
-                print(f"Unexpected response structure. 'data' key not found.")
-                break
+                send_telegram_message(f"GraphQL errors: {json.dumps(response['errors'], indent=2)}")
 
             new_positions = response['data']['siloPositions']
-            if not new_positions:
-                break
-
             high_risk_positions.extend(new_positions)
             skip += len(new_positions)
 
         except Exception as e:
-            print(f"An error occurred: {str(e)}")
-            break
+            send_telegram_message(f"An error occurred: {str(e)}")
 
     return high_risk_positions
 


### PR DESCRIPTION
Send only if the total debt ratio is above the threshold of 0.1%

TODO:
- Explain this line: `bad_debt = total_borrow_value - total_liquidation_threshold_value`. What is `total_liquidation_threshold_value`?
- Fix fetching all positions. GraphQL query will fetch only 100 positions. This is not correct: https://thegraph.com/docs/en/querying/querying-best-practices/#ask-for-what-you-want -> DONE
- In the [free plan we get 100k requests](https://thegraph.com/docs/en/billing/). This could be exceeded if we run this query hourly. On arbitrum there are 27524 positions, and each query handles up to 100 positions which is 276 queries just on arbitrum. `276 * 24 * 30 = 198.720`. -> DONE: fetch only the position with `riskFactor > 1`