### PR TITLE
chore: batch web3calls

### DIFF
--- a/aave/main.py
+++ b/aave/main.py
@@ -82,13 +82,6 @@ THRESHOLD_UR = 0.96
 THRESHOLD_UR_NOTIFICATION = 0.99
 
 
-# Build contract function
-def build_contract(address, provider_url):
-    w3 = Web3(Web3.HTTPProvider(provider_url))
-    contract = w3.eth.contract(address=address, abi=abi_atoken)
-    return contract
-
-
 def print_stuff(chain_name, token_name, ur):
     if ur > THRESHOLD_UR:
         message = (
@@ -105,23 +98,48 @@ def print_stuff(chain_name, token_name, ur):
 
 # Function to process assets for a specific network
 def process_assets(chain_name, addresses, provider_url):
-    for i in range(0, len(addresses), 2):
-        atoken_address = addresses[i]
-        underlying_token_address = addresses[i + 1]
+    w3 = Web3(Web3.HTTPProvider(provider_url))
 
-        # Build contracts
-        atoken = build_contract(atoken_address, provider_url)
-        underlying_token = build_contract(underlying_token_address, provider_url)
+    # Prepare all contracts and batch calls
+    contracts = []
+    with w3.batch_requests() as batch:
+        for i in range(0, len(addresses), 2):
+            atoken_address = addresses[i]
+            underlying_token_address = addresses[i + 1]
 
-        # Get total supply and available balance
-        ts = atoken.functions.totalSupply().call()
-        av = underlying_token.functions.balanceOf(atoken_address).call()
+            atoken = w3.eth.contract(address=atoken_address, abi=abi_atoken)
+            underlying_token = w3.eth.contract(
+                address=underlying_token_address, abi=abi_atoken
+            )
+            contracts.append((atoken, underlying_token))
+
+            # Add all calls to the batch
+            batch.add(atoken.functions.totalSupply())
+            batch.add(underlying_token.functions.balanceOf(atoken_address))
+            batch.add(underlying_token.functions.symbol())
+
+        # Execute all calls at once
+        responses = batch.execute()
+        # Calculate expected responses:
+        # - addresses.length/2 = number of token pairs
+        # - multiply by 3 because each pair needs 3 calls
+        num_pairs = len(addresses) / 2
+        expected_responses = num_pairs * 3
+        if len(responses) != expected_responses:
+            raise ValueError(
+                f"Expected {expected_responses} responses from batch, got: {len(responses)}"
+            )
+
+    # Process results
+    for i in range(0, len(responses), 3):
+        ts = responses[i]  # totalSupply
+        av = responses[i + 1]  # balanceOf
+        token_name = responses[i + 2]  # symbol
 
         # Calculate debt and utilization rate
         debt = ts - av
         ur = debt / ts if ts != 0 else 0
 
-        token_name = underlying_token.functions.symbol().call()
         print_stuff(chain_name, token_name, ur)
 
 

--- a/lido/steth/main.py
+++ b/lido/steth/main.py
@@ -50,15 +50,6 @@ def check_steth_validator_rate():
         return ta / ts
 
 
-def check_steth_crv_pool_rate(amount_in):
-    try:
-        swap_res = curve_pool.functions.get_dy(1, 0, int(amount_in)).call()
-        return swap_res
-    except Exception as e:
-        error_message = f"Error calling get_dy in curve pool: {e}"
-        send_telegram_message(error_message, PROTOCOL)
-
-
 def check_peg(validator_rate, curve_rate):
     if curve_rate == 0:
         return False
@@ -75,7 +66,6 @@ def main():
     amounts = [1e18, 100e18, 1000e18]
 
     # Create batch request
-    batch_requests = []
     with w3.batch_requests() as batch:
         # Add all curve pool requests to the batch
         for amount in amounts:

--- a/lrt-pegs/balancer/main.py
+++ b/lrt-pegs/balancer/main.py
@@ -53,7 +53,9 @@ def main():
         # Execute all calls at once
         responses = batch.execute()
         if len(responses) != len(ids):
-            raise ValueError(f"Expected {len(ids)} responses from batch, got: {len(responses)}")
+            raise ValueError(
+                f"Expected {len(ids)} responses from batch, got: {len(responses)}"
+            )
 
     # Process results outside the batch
     for (pool_name, pool_id, idx_lrt, is_nested), response in zip(ids, responses):

--- a/lrt-pegs/balancer/main.py
+++ b/lrt-pegs/balancer/main.py
@@ -6,7 +6,6 @@ from utils.telegram import send_telegram_message
 load_dotenv()
 
 provider_url = os.getenv("PROVIDER_URL_MAINNET")
-w3 = Web3(Web3.HTTPProvider(provider_url))
 w3_mainnet = Web3(Web3.HTTPProvider(provider_url))
 
 ASSET_BONDS_EXCEEDED = "GYR#357"  # https://github.com/gyrostable/gyro-pools/blob/24060707809123e1ffd222eba99a5694e4b074c7/tests/geclp/util.py#L419
@@ -42,27 +41,33 @@ ids = [
 ]
 
 
-def check_peg(pool_name, pool_id, idx_lrt, is_nested):
-    (_, balances, _) = balancer_vault.functions.getPoolTokens(pool_id).call()
-
-    total = 0
-    start_index = 1 if is_nested else 0
-
-    for i in range(start_index, len(balances)):
-        total += balances[i]
-
-    percentage = (balances[idx_lrt] / total) * 100
-    if percentage > PEG_THRESHOLD:
-        message = f"🚨 Balancer Alert! {pool_name} ratio is {percentage:.2f}% 🚀 "
-        send_telegram_message(message, PROTOCOL, True)  # disable notification
-
-
 def main():
     print("Checking for pools...")
 
-    # Loop through each pool and check its peg
-    for pool_name, pool_id, idx_lrt, is_nested in ids:
-        check_peg(pool_name, pool_id, idx_lrt, is_nested)
+    # Prepare batch calls
+    with w3_mainnet.batch_requests() as batch:
+        # Add all pool token calls to the batch
+        for pool_name, pool_id, idx_lrt, is_nested in ids:
+            batch.add(balancer_vault.functions.getPoolTokens(pool_id))
+
+        # Execute all calls at once
+        responses = batch.execute()
+        if len(responses) != len(ids):
+            raise ValueError(f"Expected {len(ids)} responses from batch, got: {len(responses)}")
+
+    # Process results outside the batch
+    for (pool_name, pool_id, idx_lrt, is_nested), response in zip(ids, responses):
+        _, balances, _ = response
+
+        total = 0
+        start_index = 1 if is_nested else 0
+        for i in range(start_index, len(balances)):
+            total += balances[i]
+
+        percentage = (balances[idx_lrt] / total) * 100
+        if percentage > PEG_THRESHOLD:
+            message = f"🚨 Balancer Alert! {pool_name} ratio is {percentage:.2f}% 🚀 "
+            send_telegram_message(message, PROTOCOL, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With more and more monitoring scripts, the time has come to optimize our web3 calls.
Now we are using batching for all web3 calls except in pendle/main.py. Need more time to optimize it but keep the readability. This will be handled in some future PR.