### PR TITLE
feat: retry web3 requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ htmlcov/
 
 # Logs
 *.log
+
+.cursorrules

--- a/aave/main.py
+++ b/aave/main.py
@@ -1,82 +1,85 @@
-from web3 import Web3
-from dotenv import load_dotenv
-import os, json
+import json
+from utils.web3_wrapper import ChainManager
+from utils.chains import Chain
 from utils.telegram import send_telegram_message
 
-load_dotenv()
 
 PROTOCOL = "aave"
-provider_url_polygon = os.getenv("PROVIDER_URL")
-provider_url_mainnet = os.getenv("PROVIDER_URL_MAINNET")
-provider_url_arb = os.getenv("PROVIDER_URL_ARBITRUM")
-provider_url_op = os.getenv("PROVIDER_URL_OPTIMISM")
 
-with open("aave/abi/AToken.json") as f:
-    abi_data = json.load(f)
-    if isinstance(abi_data, dict):
-        abi_atoken = abi_data["result"]
-    elif isinstance(abi_data, list):
-        abi_atoken = abi_data
 
-polygon_addresses = [
-    "0x1a13F4Ca1d028320A707D99520AbFefca3998b7F",  # ausdc.e
-    "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",  # usdc.e
-    "0xA4D94019934D8333Ef880ABFFbF2FDd611C762BD",  # ausdc
-    "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",  # usdc
-    "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",  # ausdt
-    "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",  # usdt
-    "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",  # adai
-    "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",  # dai
-    "0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97",  # amatic
-    "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",  # matic
-    "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",  # aweth
-    "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",  # weth
-    # Add more pairs as needed
-]
+# Load ABI
+def load_abi(file_path):
+    with open(file_path) as f:
+        abi_data = json.load(f)
+        if isinstance(abi_data, dict):
+            return abi_data["result"]
+        elif isinstance(abi_data, list):
+            return abi_data
+        else:
+            raise ValueError("Invalid ABI format")
 
-mainnet_addresses = [
-    "0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8",  # aweth
-    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",  # weth
-    "0x23878914EFE38d27C4D67Ab83ed1b93A74D4086a",  # ausdt
-    "0xdAC17F958D2ee523a2206206994597C13D831ec7",  # usdt
-    "0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c",  # ausdc
-    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # usdc
-    "0x018008bfb33d285247A21d44E50697654f754e63",  # adai
-    "0x6B175474E89094C44Da98b954EedeAC495271d0F",  # dai
-    "0xb82fa9f31612989525992FCfBB09AB22Eff5c85A",  # acrvUSD
-    "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",  # crvUSD
-]
 
-arbitrum_addresses = [
-    "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",  # aweth
-    "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",  # weth
-    "0x724dc807b04555b71ed48a6896b6F41593b8C637",  # ausdc
-    "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",  # usdc
-    "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",  # adai
-    "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",  # dai
-    "0x625E7708f30cA75bfd92586e17077590C60eb4cD",  # ausdc.e
-    "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",  # usdc.e
-    "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",  # ausdt
-    "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",  # usdt
-    "0x6533afac2E7BCCB20dca161449A13A32D391fb00",  # aarb
-    "0x912CE59144191C1204E64559FE8253a0e49E6548",  # arb
-]
+ABI_ATOKEN = load_abi("aave/abi/AToken.json")
 
-optimism_addresses = [
-    "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",  # aweth
-    "0x4200000000000000000000000000000000000006",  # weth
-    "0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5",  # ausdc
-    "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",  # usdc
-    "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",  # adai
-    "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",  # dai
-    "0x625E7708f30cA75bfd92586e17077590C60eb4cD",  # ausdc.e
-    "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",  # usdc.e
-    "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",  # ausdt
-    "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",  # usdt
-    "0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf",  # aop
-    "0x4200000000000000000000000000000000000042",  # op
-]
-
+# Map addresses by chain
+ADDRESSES_BY_CHAIN = {
+    Chain.POLYGON: [
+        "0x1a13F4Ca1d028320A707D99520AbFefca3998b7F",  # ausdc.e
+        "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",  # usdc.e
+        "0xA4D94019934D8333Ef880ABFFbF2FDd611C762BD",  # ausdc
+        "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",  # usdc
+        "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",  # ausdt
+        "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",  # usdt
+        "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",  # adai
+        "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",  # dai
+        "0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97",  # amatic
+        "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",  # matic
+        "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",  # aweth
+        "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",  # weth
+        # Add more pairs as needed
+    ],
+    Chain.MAINNET: [
+        "0x4d5F47FA6A74757f35C14fD3a6Ef8E3C9BC514E8",  # aweth
+        "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",  # weth
+        "0x23878914EFE38d27C4D67Ab83ed1b93A74D4086a",  # ausdt
+        "0xdAC17F958D2ee523a2206206994597C13D831ec7",  # usdt
+        "0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c",  # ausdc
+        "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # usdc
+        "0x018008bfb33d285247A21d44E50697654f754e63",  # adai
+        "0x6B175474E89094C44Da98b954EedeAC495271d0F",  # dai
+        "0xb82fa9f31612989525992FCfBB09AB22Eff5c85A",  # acrvUSD
+        "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E",  # crvUSD
+    ],
+    Chain.ARBITRUM: [
+        "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",  # aweth
+        "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",  # weth
+        "0x724dc807b04555b71ed48a6896b6F41593b8C637",  # ausdc
+        "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",  # usdc
+        "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",  # adai
+        "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",  # dai
+        "0x625E7708f30cA75bfd92586e17077590C60eb4cD",  # ausdc.e
+        "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",  # usdc.e
+        "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",  # ausdt
+        "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",  # usdt
+        "0x6533afac2E7BCCB20dca161449A13A32D391fb00",  # aarb
+        "0x912CE59144191C1204E64559FE8253a0e49E6548",  # arb
+    ],
+    # We don't use optimism - add if needed
+    # Chain.OPTIMISM: [
+    #     "0xe50fA9b3c56FfB159cB0FCA61F5c9D750e8128c8",  # aweth
+    #     "0x4200000000000000000000000000000000000006",  # weth
+    #     "0x38d693cE1dF5AaDF7bC62595A37D667aD57922e5",  # ausdc
+    #     "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",  # usdc
+    #     "0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",  # adai
+    #     "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",  # dai
+    #     "0x625E7708f30cA75bfd92586e17077590C60eb4cD",  # ausdc.e
+    #     "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",  # usdc.e
+    #     "0x6ab707Aca953eDAeFBc4fD23bA73294241490620",  # ausdt
+    #     "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",  # usdt
+    #     "0x513c7E3a9c69cA3e22550eF58AC1C0088e918FFf",  # aop
+    #     "0x4200000000000000000000000000000000000042",  # op
+    # ]
+}
 
 THRESHOLD_UR = 0.99
 THRESHOLD_UR_NOTIFICATION = 0.99
@@ -96,33 +99,28 @@ def print_stuff(chain_name, token_name, ur):
         send_telegram_message(message, PROTOCOL, disable_notification)
 
 
-# Function to process assets for a specific network
-def process_assets(chain_name, addresses, provider_url):
-    w3 = Web3(Web3.HTTPProvider(provider_url))
+def process_assets(chain: Chain):
+    client = ChainManager.get_client(chain)
+    addresses = ADDRESSES_BY_CHAIN[chain]
 
     # Prepare all contracts and batch calls
     contracts = []
-    with w3.batch_requests() as batch:
+    with client.batch_requests() as batch:
         for i in range(0, len(addresses), 2):
             atoken_address = addresses[i]
             underlying_token_address = addresses[i + 1]
 
-            atoken = w3.eth.contract(address=atoken_address, abi=abi_atoken)
-            underlying_token = w3.eth.contract(
-                address=underlying_token_address, abi=abi_atoken
+            atoken = client.eth.contract(address=atoken_address, abi=ABI_ATOKEN)
+            underlying_token = client.eth.contract(
+                address=underlying_token_address, abi=ABI_ATOKEN
             )
             contracts.append((atoken, underlying_token))
 
-            # Add all calls to the batch
             batch.add(atoken.functions.totalSupply())
             batch.add(underlying_token.functions.balanceOf(atoken_address))
             batch.add(underlying_token.functions.symbol())
 
-        # Execute all calls at once
-        responses = batch.execute()
-        # Calculate expected responses:
-        # - addresses.length/2 = number of token pairs
-        # - multiply by 3 because each pair needs 3 calls
+        responses = client.execute_batch(batch)
         num_pairs = len(addresses) / 2
         expected_responses = num_pairs * 3
         if len(responses) != expected_responses:
@@ -136,28 +134,17 @@ def process_assets(chain_name, addresses, provider_url):
         av = responses[i + 1]  # balanceOf
         token_name = responses[i + 2]  # symbol
 
-        # Calculate debt and utilization rate
         debt = ts - av
         ur = debt / ts if ts != 0 else 0
 
-        print_stuff(chain_name, token_name, ur)
+        print_stuff(chain.name, token_name, ur)
 
 
-# Main function
 def main():
-    print("Processing Polygon assets...")
-    process_assets("Polygon", polygon_addresses, provider_url_polygon)
-
-    print("Processing Mainnet assets...")
-    process_assets("Mainnet", mainnet_addresses, provider_url_mainnet)
-
-    print("Processing Arbitrum assets...")
-    process_assets("Arbitrum", arbitrum_addresses, provider_url_arb)
-
-    print("Processing Optimism assets...")
-    process_assets("Optimism", optimism_addresses, provider_url_op)
+    for chain in [Chain.POLYGON, Chain.MAINNET, Chain.ARBITRUM]:
+        print(f"Processing {chain.name} assets...")
+        process_assets(chain)
 
 
-# Run the main function
 if __name__ == "__main__":
     main()

--- a/compound/main.py
+++ b/compound/main.py
@@ -1,7 +1,7 @@
+import json
 from utils.web3_wrapper import ChainManager
 from utils.chains import Chain
 from utils.telegram import send_telegram_message
-import json
 
 PROTOCOL = "comp"
 THRESHOLD_UR = 0.99
@@ -94,7 +94,7 @@ def process_assets(chain: Chain):
 
 
 def main():
-    for chain in [Chain.POLYGON, Chain.MAINNET, Chain.ARBITRUM, Chain.OPTIMISM]:
+    for chain in [Chain.POLYGON, Chain.MAINNET, Chain.ARBITRUM]:
         print(f"Processing {chain.name} assets...")
         process_assets(chain)
 

--- a/compound/main.py
+++ b/compound/main.py
@@ -1,65 +1,59 @@
-from web3 import Web3
-from dotenv import load_dotenv
-import os, json
+from utils.web3_wrapper import ChainManager
+from utils.chains import Chain
 from utils.telegram import send_telegram_message
-
-load_dotenv()
+import json
 
 PROTOCOL = "comp"
 THRESHOLD_UR = 0.99
 THRESHOLD_UR_NOTIFICATION = 0.99
 
-provider_url_polygon = os.getenv("PROVIDER_URL")
-provider_url_mainnet = os.getenv("PROVIDER_URL_MAINNET")
-provider_url_arb = os.getenv("PROVIDER_URL_ARBITRUM")
-provider_url_op = os.getenv("PROVIDER_URL_OPTIMISM")
 
-with open("compound/abi/CTokenV3.json") as f:
-    abi_data = json.load(f)
-    if isinstance(abi_data, dict):
-        abi_ctoken = abi_data["result"]
-    elif isinstance(abi_data, list):
-        abi_ctoken = abi_data
+def load_abi(file_path):
+    with open(file_path) as f:
+        abi_data = json.load(f)
+        if isinstance(abi_data, dict):
+            return abi_data["result"]
+        elif isinstance(abi_data, list):
+            return abi_data
+        else:
+            raise ValueError("Invalid ABI format")
 
-polygon_addresses = [
-    "0xF25212E676D1F7F89Cd72fFEe66158f541246445",
-    "cUSDC.Ev3",
-    "0xaeB318360f27748Acb200CE616E389A6C9409a07",
-    "cUSDTv3",
-    # Add more pairs as needed
-]
 
-mainnet_addresses = [
-    "0x3Afdc9BCA9213A35503b077a6072F3D0d5AB0840",
-    "cUSDTv3",
-    "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
-    "cUSDCv3",
-    "0xA17581A9E3356d9A858b789D68B4d866e593aE94",
-    "cWETHv3",
-    # Add more pairs as needed
-]
+ABI_CTOKEN = load_abi("compound/abi/CTokenV3.json")
 
-arbitrum_addresses = [
-    "0xd98Be00b5D27fc98112BdE293e487f8D4cA57d07",
-    "cUSDTv3",
-    "0x6f7D514bbD4aFf3BcD1140B7344b32f063dEe486",
-    "cWETHv3",
-    "0xA5EDBDD9646f8dFF606d7448e414884C7d905dCA",
-    "cUSDC.Ev3",
-    "0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf",
-    "cUSDCv3",
-    # Add more pairs as needed
-]
-
-optimism_addresses = [
-    "0x2e44e174f7D53F0212823acC11C01A11d58c5bCB",
-    "cUSDCv3",
-    "0x995E394b8B2437aC8Ce61Ee0bC610D617962B214",
-    "cUSDTv3",
-    "0xE36A30D249f7761327fd973001A32010b521b6Fd",
-    "cWETHv3",
-    # Add more pairs as needed
-]
+# Map addresses by chain
+ADDRESSES_BY_CHAIN = {
+    Chain.POLYGON: [
+        "0xF25212E676D1F7F89Cd72fFEe66158f541246445",
+        "cUSDC.Ev3",
+        "0xaeB318360f27748Acb200CE616E389A6C9409a07",
+        "cUSDTv3",
+    ],
+    Chain.MAINNET: [
+        "0x3Afdc9BCA9213A35503b077a6072F3D0d5AB0840",
+        "cUSDTv3",
+        "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+        "cUSDCv3",
+        "0xA17581A9E3356d9A858b789D68B4d866e593aE94",
+        "cWETHv3",
+    ],
+    Chain.ARBITRUM: [
+        "0xd98Be00b5D27fc98112BdE293e487f8D4cA57d07",
+        "cUSDTv3",
+        "0x6f7D514bbD4aFf3BcD1140B7344b32f063dEe486",
+        "cWETHv3",
+        "0xA5EDBDD9646f8dFF606d7448e414884C7d905dCA",
+        "cUSDC.Ev3",
+        "0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf",
+        "cUSDCv3",
+    ],
+    # We don't use optimism - add if needed
+    # Chain.OPTIMISM: [
+    #     "0x2e44e174f7D53F0212823acC11C01A11d58c5bCB", "cUSDCv3",
+    #     "0x995E394b8B2437aC8Ce61Ee0bC610D617962B214", "cUSDTv3",
+    #     "0xE36A30D249f7761327fd973001A32010b521b6Fd", "cWETHv3",
+    # ]
+}
 
 
 def print_stuff(chain_name, token_name, ur):
@@ -70,56 +64,40 @@ def print_stuff(chain_name, token_name, ur):
             f"📊 Utilization rate: {ur:.2%}\n"
             f"🌐 Chain: {chain_name}"
         )
-        disable_notification = True
-        if ur > THRESHOLD_UR_NOTIFICATION:
-            disable_notification = False
+        disable_notification = True if ur <= THRESHOLD_UR_NOTIFICATION else False
         send_telegram_message(message, PROTOCOL, disable_notification)
 
 
-def process_assets(chain_name, addresses, provider_url):
-    w3 = Web3(Web3.HTTPProvider(provider_url))
+def process_assets(chain: Chain):
+    client = ChainManager.get_client(chain)
+    addresses = ADDRESSES_BY_CHAIN[chain]
 
-    # Prepare batch calls
-    with w3.batch_requests() as batch:
+    with client.batch_requests() as batch:
         contracts = []
         for i in range(0, len(addresses), 2):
             ctoken_address = addresses[i]
-            ctoken = w3.eth.contract(address=ctoken_address, abi=abi_ctoken)
+            ctoken = client.eth.contract(address=ctoken_address, abi=ABI_CTOKEN)
             contracts.append(ctoken)
-
-            # Add utilization call to batch
             batch.add(ctoken.functions.getUtilization())
 
-        # Execute all calls at once
-        responses = batch.execute()
-        expected_responses = len(addresses) / 2  # 1 call per token pair
+        responses = client.execute_batch(batch)
+        expected_responses = len(addresses) // 2
         if len(responses) != expected_responses:
             raise ValueError(
                 f"Expected {expected_responses} responses from batch, got: {len(responses)}"
             )
 
-    # Process results
-    for i in range(len(responses)):
-        ur = int(responses[i]) / 1e18  # unscale it
-        ctoken_name = addresses[i * 2 + 1]  # get token name from addresses array
-        print_stuff(chain_name, ctoken_name, ur)
+    for i, response in enumerate(responses):
+        ur = int(response) / 1e18
+        ctoken_name = addresses[i * 2 + 1]
+        print_stuff(chain.name, ctoken_name, ur)
 
 
-# Main function
 def main():
-    print("Processing Polygon assets...")
-    process_assets("Polygon", polygon_addresses, provider_url_polygon)
-
-    print("Processing Mainnet assets...")
-    process_assets("Mainnet", mainnet_addresses, provider_url_mainnet)
-
-    print("Processing Arbitrum assets...")
-    process_assets("Arbitrum", arbitrum_addresses, provider_url_arb)
-
-    print("Processing Optimism assets...")
-    process_assets("Optimism", optimism_addresses, provider_url_op)
+    for chain in [Chain.POLYGON, Chain.MAINNET, Chain.ARBITRUM, Chain.OPTIMISM]:
+        print(f"Processing {chain.name} assets...")
+        process_assets(chain)
 
 
-# Run the main function
 if __name__ == "__main__":
     main()

--- a/lido/steth/main.py
+++ b/lido/steth/main.py
@@ -1,48 +1,40 @@
-from web3 import Web3
-from dotenv import load_dotenv
-import os, json
+import json
+from utils.web3_wrapper import ChainManager
+from utils.chains import Chain
 from utils.telegram import send_telegram_message
 
-load_dotenv()
-
 PROTOCOL = "LIDO"
-peg_threshold = 0.05  # 5% used
-provider_url = os.getenv("PROVIDER_URL_MAINNET")
-w3 = Web3(Web3.HTTPProvider(provider_url))
-
-with open("common-abi/CurvePool.json") as f:
-    abi_data = json.load(f)
-    if isinstance(abi_data, dict):
-        abi_curve_pool = abi_data["result"]
-    elif isinstance(abi_data, list):
-        abi_curve_pool = abi_data
-
-with open("lido/steth/abi/Steth.json") as f:
-    abi_data = json.load(f)
-    if isinstance(abi_data, dict):
-        abi_steth = abi_data["result"]
-    elif isinstance(abi_data, list):
-        abi_steth = abi_data
+PEG_THRESHOLD = 0.05  # 5% threshold
 
 
-steth = w3.eth.contract(
-    address="0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84", abi=abi_steth
-)
-curve_pool = w3.eth.contract(
-    address="0xDC24316b9AE028F1497c275EB9192a3Ea0f67022", abi=abi_curve_pool
-)
+def load_abi(file_path):
+    with open(file_path) as f:
+        abi_data = json.load(f)
+        if isinstance(abi_data, dict):
+            return abi_data["result"]
+        elif isinstance(abi_data, list):
+            return abi_data
+        else:
+            raise ValueError("Invalid ABI format")
 
 
-def check_steth_validator_rate():
-    # Use batch requests
-    with w3.batch_requests() as batch:
-        # Add calls to the batch
+# Load ABIs
+ABI_CURVE_POOL = load_abi("common-abi/CurvePool.json")
+ABI_STETH = load_abi("lido/steth/abi/Steth.json")
+
+# Contract addresses
+STETH_ADDRESS = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+CURVE_POOL_ADDRESS = "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022"
+
+
+def check_steth_validator_rate(client):
+    steth = client.eth.contract(address=STETH_ADDRESS, abi=ABI_STETH)
+
+    with client.batch_requests() as batch:
         batch.add(steth.functions.totalSupply())
         batch.add(steth.functions.getTotalPooledEther())
 
-        # Execute all calls at once
-        responses = batch.execute()
-
+        responses = client.execute_batch(batch)
         if len(responses) != 2:
             raise ValueError(f"Expected 2 responses from batch, got: {len(responses)}")
 
@@ -53,26 +45,26 @@ def check_steth_validator_rate():
 def check_peg(validator_rate, curve_rate):
     if curve_rate == 0:
         return False
-    # Calculate the percentage difference
     difference = abs(validator_rate - curve_rate)
     percentage_diff = difference / validator_rate
-    return percentage_diff >= peg_threshold  # 0.06 >= 0.05
+    return percentage_diff >= PEG_THRESHOLD
 
 
 def main():
-    validator_rate_unscaled = check_steth_validator_rate()
+    client = ChainManager.get_client(Chain.MAINNET)
+    curve_pool = client.eth.contract(address=CURVE_POOL_ADDRESS, abi=ABI_CURVE_POOL)
+
+    validator_rate_unscaled = check_steth_validator_rate(client)
     message = f"🔄 1 stETH is: {validator_rate_unscaled:.5f} ETH in Lido\n"
 
     amounts = [1e18, 100e18, 1000e18]
 
-    # Create batch request
-    with w3.batch_requests() as batch:
-        # Add all curve pool requests to the batch
+    with client.batch_requests() as batch:
         for amount in amounts:
             batch.add(curve_pool.functions.get_dy(1, 0, int(amount)))
-        # Execute all at once and store responses
+
         try:
-            curve_rates = batch.execute()
+            curve_rates = client.execute_batch(batch)
             if len(curve_rates) != len(amounts):
                 error_message = f"Batch response length mismatch. Expected: {len(amounts)}, Got: {len(curve_rates)}"
                 send_telegram_message(error_message, PROTOCOL)
@@ -82,20 +74,19 @@ def main():
             send_telegram_message(error_message, PROTOCOL)
             return
 
-    # Process results outside the batch to save rpc calls
-    for amount, curve_rate in zip(amounts, curve_rates):
-        try:
-            validator_rate_scaled = validator_rate_unscaled * amount
-            if curve_rate is not None and check_peg(validator_rate_scaled, curve_rate):
-                human_readable_amount = amount / 1e18
-                human_readable_result = curve_rate / 1e18
-                message += f"📊 Swap result for amount {human_readable_amount:.5f}: {human_readable_result:.5f}"
-                send_telegram_message(message, PROTOCOL)
-        except Exception as e:
-            error_message = (
-                f"Error processing curve pool rate for amount {amount/1e18:.2f}: {e}"
-            )
-            send_telegram_message(error_message, PROTOCOL)
+        for amount, curve_rate in zip(amounts, curve_rates):
+            try:
+                validator_rate_scaled = validator_rate_unscaled * amount
+                if curve_rate is not None and check_peg(
+                    validator_rate_scaled, curve_rate
+                ):
+                    human_readable_amount = amount / 1e18
+                    human_readable_result = curve_rate / 1e18
+                    message += f"📊 Swap result for amount {human_readable_amount:.5f}: {human_readable_result:.5f}"
+                    send_telegram_message(message, PROTOCOL)
+            except Exception as e:
+                error_message = f"Error processing curve pool rate for amount {amount/1e18:.2f}: {e}"
+                send_telegram_message(error_message, PROTOCOL)
 
 
 if __name__ == "__main__":

--- a/lrt-pegs/balancer/main.py
+++ b/lrt-pegs/balancer/main.py
@@ -1,30 +1,32 @@
-from web3 import Web3
-from dotenv import load_dotenv
-import os, json
+import json
+from utils.web3_wrapper import ChainManager
+from utils.chains import Chain
 from utils.telegram import send_telegram_message
 
-load_dotenv()
-
-provider_url = os.getenv("PROVIDER_URL_MAINNET")
-w3_mainnet = Web3(Web3.HTTPProvider(provider_url))
-
-ASSET_BONDS_EXCEEDED = "GYR#357"  # https://github.com/gyrostable/gyro-pools/blob/24060707809123e1ffd222eba99a5694e4b074c7/tests/geclp/util.py#L419
+ASSET_BONDS_EXCEEDED = "GYR#357"
 PROTOCOL = "PEGS"
 PEG_THRESHOLD = 80
 
-with open("common-abi/BalancerVault.json") as f:
-    abi_data = json.load(f)
-    if isinstance(abi_data, dict):
-        abi_bv = abi_data["result"]
-    elif isinstance(abi_data, list):
-        abi_bv = abi_data
 
-balancer_vault = w3_mainnet.eth.contract(
-    address="0xBA12222222228d8Ba445958a75a0704d566BF2C8", abi=abi_bv
-)
+def load_abi(file_path):
+    with open(file_path) as f:
+        abi_data = json.load(f)
+        if isinstance(abi_data, dict):
+            return abi_data["result"]
+        elif isinstance(abi_data, list):
+            return abi_data
+        else:
+            raise ValueError("Invalid ABI format")
 
-ids = [
-    # name, pool id, index of lrt, is BPT token an underlying token of the balancer pool?
+
+# Load Balancer Vault ABI
+ABI_BALANCER_VAULT = load_abi("common-abi/BalancerVault.json")
+
+BALANCER_VAULT_ADDRESS = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+
+# Pool configurations
+POOL_CONFIGS = [
+    # name, pool id, index of lrt, is BPT token an underlying token?
     (
         "Renzo ezETH-WETH 50-50 Pool",
         "0x596192bb6e41802428ac943d2f1476c1af25cc0e000000000000000000000659",
@@ -37,28 +39,26 @@ ids = [
         1,
         True,
     ),
-    # Add more pool names and IDs here as needed in the future
 ]
 
 
-def main():
-    print("Checking for pools...")
+def process_pools(chain: Chain = Chain.MAINNET):
+    client = ChainManager.get_client(chain)
+    vault = client.eth.contract(address=BALANCER_VAULT_ADDRESS, abi=ABI_BALANCER_VAULT)
 
     # Prepare batch calls
-    with w3_mainnet.batch_requests() as batch:
-        # Add all pool token calls to the batch
-        for pool_name, pool_id, idx_lrt, is_nested in ids:
-            batch.add(balancer_vault.functions.getPoolTokens(pool_id))
+    with client.batch_requests() as batch:
+        for pool_name, pool_id, _, _ in POOL_CONFIGS:
+            batch.add(vault.functions.getPoolTokens(pool_id))
 
-        # Execute all calls at once
-        responses = batch.execute()
-        if len(responses) != len(ids):
+        responses = client.execute_batch(batch)
+        if len(responses) != len(POOL_CONFIGS):
             raise ValueError(
-                f"Expected {len(ids)} responses from batch, got: {len(responses)}"
+                f"Expected {len(POOL_CONFIGS)} responses from batch, got: {len(responses)}"
             )
 
-    # Process results outside the batch
-    for (pool_name, pool_id, idx_lrt, is_nested), response in zip(ids, responses):
+    # Process results
+    for (pool_name, _, idx_lrt, is_nested), response in zip(POOL_CONFIGS, responses):
         _, balances, _ = response
 
         total = 0
@@ -70,6 +70,11 @@ def main():
         if percentage > PEG_THRESHOLD:
             message = f"🚨 Balancer Alert! {pool_name} ratio is {percentage:.2f}% 🚀 "
             send_telegram_message(message, PROTOCOL, True)
+
+
+def main():
+    print("Checking Balancer pools...")
+    process_pools()
 
 
 if __name__ == "__main__":

--- a/morpho/main.py
+++ b/morpho/main.py
@@ -35,8 +35,9 @@ VAULTS_BY_CHAIN = {
         ["Moonwell Flagship USDC", "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca"],
         ["Moonwell Flagship ETH", "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1"],
         ["Moonwell Flagship EURC", "0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026"],
-    ]
+    ],
 }
+
 
 # Load ABI files
 def load_abi(file_path):

--- a/morpho/main.py
+++ b/morpho/main.py
@@ -1,13 +1,13 @@
-from utils.web3_wrapper import ChainManager
-from utils.chains import Chain
-import json
-from web3 import Web3
 from datetime import datetime
-from utils.telegram import send_telegram_message
+import json
 from utils.cache import (
     get_last_executed_morpho_from_file,
     write_last_executed_morpho_to_file,
 )
+from utils.chains import Chain
+from utils.telegram import send_telegram_message
+from utils.web3_wrapper import ChainManager
+from web3 import Web3
 
 PROTOCOL = "MORPHO"
 MARKET_URL = "https://app.morpho.org/market"

--- a/morpho/main.py
+++ b/morpho/main.py
@@ -1,6 +1,7 @@
+from utils.web3_wrapper import ChainManager
+from utils.chains import Chain
+import json
 from web3 import Web3
-from dotenv import load_dotenv
-import os, json
 from datetime import datetime
 from utils.telegram import send_telegram_message
 from utils.cache import (
@@ -8,39 +9,34 @@ from utils.cache import (
     write_last_executed_morpho_to_file,
 )
 
-# Load environment variables
-load_dotenv()
-
 PROTOCOL = "MORPHO"
 MARKET_URL = "https://app.morpho.org/market"
 VAULT_URL = "https://app.morpho.org/vault"
-# Provider URLs
-PROVIDER_URL_MAINNET = os.getenv("PROVIDER_URL_MAINNET")
-PROVIDER_URL_BASE = os.getenv("PROVIDER_URL_BASE")
 
 PENDING_CAP_TYPE = "pending_cap"
 REMOVABLE_AT_TYPE = "removable_at"
 
-# format of the vault list item is: [name, address]
-MAINNET_VAULTS = [
-    ["Steakhouse USDC", "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB"],
-    ["Steakhouse USDT", "0xbEef047a543E45807105E51A8BBEFCc5950fcfBa"],
-    ["Usual Boosted USDC", "0xd63070114470f685b75B74D60EEc7c1113d33a3D"],
-    ["Gantlet WETH Prime", "0x2371e134e3455e0593363cBF89d3b6cf53740618"],
-    ["Gauntlet USDC Prime", "0xdd0f28e19C1780eb6396170735D45153D261490d"],
-    ["Gauntlet USDT Prime", "0x8CB3649114051cA5119141a34C200D65dc0Faa73"],
-    ["Gauntlet WETH Core", "0x4881Ef0BF6d2365D3dd6499ccd7532bcdBCE0658"],
-    ["Gantlet USDC Core", "0x8eB67A509616cd6A7c1B3c8C21D48FF57df3d458"],
-    ["Gantlet DAI Core", "0x500331c9fF24D9d11aee6B07734Aa72343EA74a5"],
-    ["Gantlet WBTC Core", "0x443df5eEE3196e9b2Dd77CaBd3eA76C3dee8f9b2"],
-    ["LlamaRisk crvUSD Vault", "0x67315dd969B8Cd3a3520C245837Bf71f54579C75"],
-]
-BASE_VAULTS = [
-    ["Moonwell Flagship USDC", "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca"],
-    ["Moonwell Flagship ETH", "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1"],
-    ["Moonwell Flagship EURC", "0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026"],
-]
-
+# Map vaults by chain
+VAULTS_BY_CHAIN = {
+    Chain.MAINNET: [
+        ["Steakhouse USDC", "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB"],
+        ["Steakhouse USDT", "0xbEef047a543E45807105E51A8BBEFCc5950fcfBa"],
+        ["Usual Boosted USDC", "0xd63070114470f685b75B74D60EEc7c1113d33a3D"],
+        ["Gantlet WETH Prime", "0x2371e134e3455e0593363cBF89d3b6cf53740618"],
+        ["Gauntlet USDC Prime", "0xdd0f28e19C1780eb6396170735D45153D261490d"],
+        ["Gauntlet USDT Prime", "0x8CB3649114051cA5119141a34C200D65dc0Faa73"],
+        ["Gauntlet WETH Core", "0x4881Ef0BF6d2365D3dd6499ccd7532bcdBCE0658"],
+        ["Gantlet USDC Core", "0x8eB67A509616cd6A7c1B3c8C21D48FF57df3d458"],
+        ["Gantlet DAI Core", "0x500331c9fF24D9d11aee6B07734Aa72343EA74a5"],
+        ["Gantlet WBTC Core", "0x443df5eEE3196e9b2Dd77CaBd3eA76C3dee8f9b2"],
+        ["LlamaRisk crvUSD Vault", "0x67315dd969B8Cd3a3520C245837Bf71f54579C75"],
+    ],
+    Chain.BASE: [
+        ["Moonwell Flagship USDC", "0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca"],
+        ["Moonwell Flagship ETH", "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1"],
+        ["Moonwell Flagship EURC", "0xf24608E0CCb972b0b0f4A6446a0BBf58c701a026"],
+    ]
+}
 
 # Load ABI files
 def load_abi(file_path):
@@ -57,15 +53,16 @@ def load_abi(file_path):
 ABI_MORPHO = load_abi("morpho/abi/morpho.json")
 
 
-def get_market_url(market, chain):
-    return f"{MARKET_URL}?id={market}&network={chain}"
+def get_market_url(market, chain: Chain):
+    chain_name = chain.name.lower()
+    return f"{MARKET_URL}?id={market}&network={chain_name}"
 
 
-def get_vault_url_by_name(vault_name, chain):
-    vaults = MAINNET_VAULTS if chain == "mainnet" else BASE_VAULTS
+def get_vault_url_by_name(vault_name, chain: Chain):
+    vaults = VAULTS_BY_CHAIN[chain]
     for name, address in vaults:
         if name == vault_name:
-            return f"{VAULT_URL}?vault={address}&network={chain}"
+            return f"{VAULT_URL}?vault={address}&network={chain.name.lower()}"
     return None
 
 
@@ -74,7 +71,7 @@ def check_markets_pending_cap(name, morpho_contract, chain, w3):
         batch.add(morpho_contract.functions.supplyQueueLength())
         batch.add(morpho_contract.functions.withdrawQueueLength())
 
-        length_responses = batch.execute()
+        length_responses = w3.execute_batch(batch)
         if len(length_responses) != 2:
             raise ValueError(
                 "Expected 2 responses from batch(supplyQueueLength+withdrawQueueLength), got: ",
@@ -89,7 +86,7 @@ def check_markets_pending_cap(name, morpho_contract, chain, w3):
             batch.add(morpho_contract.functions.supplyQueue(i))
         for i in range(length_of_withdraw_queue):
             batch.add(morpho_contract.functions.withdrawQueue(i))
-        market_responses = batch.execute()
+        market_responses = w3.execute_batch(batch)
         if len(market_responses) != length_of_supply_queue + length_of_withdraw_queue:
             raise ValueError(
                 "Expected ",
@@ -104,7 +101,7 @@ def check_markets_pending_cap(name, morpho_contract, chain, w3):
         for market in markets:
             batch.add(morpho_contract.functions.pendingCap(market))
             batch.add(morpho_contract.functions.config(market))
-        pending_cap_and_config_responses = batch.execute()
+        pending_cap_and_config_responses = w3.execute_batch(batch)
         if len(pending_cap_and_config_responses) != len(markets) * 2:
             raise ValueError(
                 "Expected ",
@@ -199,11 +196,11 @@ def check_pending_role_change(name, morpho_contract, role_type, timestamp, chain
         )
 
 
-def check_timelock_and_guardian(name, morpho_contract, chain):
+def check_timelock_and_guardian(name, morpho_contract, chain, client):
     with morpho_contract.w3.batch_requests() as batch:
         batch.add(morpho_contract.functions.pendingTimelock())
         batch.add(morpho_contract.functions.pendingGuardian())
-        responses = batch.execute()
+        responses = client.execute_batch(batch)
         if len(responses) != 2:
             raise ValueError("Expected 2 responses from batch, got: ", len(responses))
 
@@ -214,30 +211,22 @@ def check_timelock_and_guardian(name, morpho_contract, chain):
     check_pending_role_change(name, morpho_contract, "guardian", guardian, chain)
 
 
-def get_data_for_chain(chain):
-    if chain == "mainnet":
-        w3 = Web3(Web3.HTTPProvider(PROVIDER_URL_MAINNET))
-        vaults = MAINNET_VAULTS
-    elif chain == "base":
-        w3 = Web3(Web3.HTTPProvider(PROVIDER_URL_BASE))
-        vaults = BASE_VAULTS
-    else:
-        raise ValueError("Invalid chain")
+def get_data_for_chain(chain: Chain):
+    client = ChainManager.get_client(chain)
+    vaults = VAULTS_BY_CHAIN[chain]
 
-    print(f"Processing Morpho Vaults on {chain} ...")
+    print(f"Processing Morpho Vaults on {chain.name} ...")
     print(f"Vaults: {vaults}")
 
     for vault in vaults:
-        # TODO: additional optimization is possible by combining marketes of all vaults into one list
-        # and then checking the pending caps for all markets in one batch request
-        morpho_contract = w3.eth.contract(address=vault[1], abi=ABI_MORPHO)
-        check_markets_pending_cap(vault[0], morpho_contract, chain, w3)
-        check_timelock_and_guardian(vault[0], morpho_contract, chain)
+        morpho_contract = client.eth.contract(address=vault[1], abi=ABI_MORPHO)
+        check_markets_pending_cap(vault[0], morpho_contract, chain, client)
+        check_timelock_and_guardian(vault[0], morpho_contract, chain, client)
 
 
 def main():
-    get_data_for_chain("mainnet")
-    get_data_for_chain("base")
+    get_data_for_chain(Chain.MAINNET)
+    get_data_for_chain(Chain.BASE)
 
 
 if __name__ == "__main__":

--- a/pendle/main.py
+++ b/pendle/main.py
@@ -1,49 +1,38 @@
-from web3 import Web3
-from dotenv import load_dotenv
-import os, json, datetime
+from utils.web3_wrapper import ChainManager
+from utils.chains import Chain
 from utils.telegram import send_telegram_message
+import json, datetime
 
 # Constants
 DURATION = 1800  # 30 minutes
 THRESHOLD_RATIO = 0.95
 PROTOCOL = "PENDLE"
 
-# Load environment variables
-load_dotenv()
-
-# Provider URLs
-PROVIDER_URL_MAINNET = os.getenv("PROVIDER_URL_MAINNET")
-PROVIDER_URL_ARB = os.getenv("PROVIDER_URL_ARBITRUM")
-
 # Oracle address
 ORACLE_ADDRESS = "0x14418800E0B4C971905423aa873e83355922428c"
 
-# Vault addresses
-ARBITRUM_VAULTS = [
-    "0x044E75fCbF7BD3f8f4577FF317554e9c0037F145",  # weeth
-    "0x1Dd930ADD968ff5913C3627dAA1e6e6FCC9dc544",  # kelp dao eth
-    "0x34a2b066AF16409648eF15d239E656edB8790ca0",  # usde
-]
-
-MAINNET_VAULTS = [
-    "0xe5175a2EB7C40bC5f0E9DE4152caA14eab0fFCb7",  # weeth symbiotic
-    "0xDDa02A2FA0bb0ee45Ba9179a3fd7e65E5D3B2C90",  # ageth
-    "0x2F2BBc50DB252eeADD2c9B9197beb6e5Aef87e48",  # ena
-    "0x57a8b4061AA598d2Bb5f70C5F931a75C9F511fc8",  # lbtc corn
-    "0x57fC2D9809F777Cd5c8C433442264B6E8bE7Fce4",  # sUSDe
-]
+# Map vaults by chain
+VAULTS_BY_CHAIN = {
+    Chain.ARBITRUM: [
+        "0x044E75fCbF7BD3f8f4577FF317554e9c0037F145",  # weeth
+        "0x1Dd930ADD968ff5913C3627dAA1e6e6FCC9dc544",  # kelp dao eth
+        "0x34a2b066AF16409648eF15d239E656edB8790ca0",  # usde
+    ],
+    Chain.MAINNET: [
+        "0xe5175a2EB7C40bC5f0E9DE4152caA14eab0fFCb7",  # weeth symbiotic
+        "0xDDa02A2FA0bb0ee45Ba9179a3fd7e65E5D3B2C90",  # ageth
+        "0x2F2BBc50DB252eeADD2c9B9197beb6e5Aef87e48",  # ena
+        "0x57a8b4061AA598d2Bb5f70C5F931a75C9F511fc8",  # lbtc corn
+        "0x57fC2D9809F777Cd5c8C433442264B6E8bE7Fce4",  # sUSDe
+    ],
+}
 
 
 # Load ABI files
 def load_abi(file_path):
     with open(file_path) as f:
         abi_data = json.load(f)
-        if isinstance(abi_data, dict):
-            return abi_data["result"]
-        elif isinstance(abi_data, list):
-            return abi_data
-        else:
-            raise ValueError("Invalid ABI format")
+        return abi_data["result"] if isinstance(abi_data, dict) else abi_data
 
 
 ABI_ORACLE = load_abi("pendle/abi/PendleYPLpOracle.json")
@@ -52,84 +41,90 @@ ABI_STRATEGY = load_abi("pendle/abi/PendleStrategy.json")
 ABI_MARKET = load_abi("pendle/abi/PendleMarket.json")
 
 
-def get_ratio_for_market(market, oracle):
-    pt_ratio = oracle.functions.getPtToAssetRate(market, DURATION).call()
-    pt_ratio_readable = pt_ratio / 1e18
-    print(f"PT to Asset Ratio for {market}: {pt_ratio_readable}")
-    return pt_ratio_readable
+def process_assets(chain: Chain):
+    client = ChainManager.get_client(chain)
+    vaults = VAULTS_BY_CHAIN[chain]
+    oracle = client.eth.contract(address=ORACLE_ADDRESS, abi=ABI_ORACLE)
 
+    # First batch: Get strategies and names for all vaults
+    strategies_data = []
+    with client.batch_requests() as batch:
+        for vault_address in vaults:
+            vault = client.eth.contract(address=vault_address, abi=ABI_VAULT)
+            batch.add(vault.functions.get_default_queue())
+            batch.add(vault.functions.name())
+        responses = client.execute_batch(batch)
 
-def get_strategies_from_vault(vault, w3):
-    vault_contract = w3.eth.contract(address=vault, abi=ABI_VAULT)
-    strategies = vault_contract.functions.get_default_queue().call()
-    name = vault_contract.functions.name().call()
-    strategies_with_assets = [
-        strategy
-        for strategy in strategies
-        if w3.eth.contract(address=strategy, abi=ABI_STRATEGY)
-        .functions.totalAssets()
-        .call()
-        > 1e9
-        and not w3.eth.contract(address=strategy, abi=ABI_STRATEGY)
-        .functions.isExpired()
-        .call()
-    ]
-    print(f"Strategies for {name}: {strategies_with_assets}")
-    return strategies_with_assets, name
+    # Process vault responses and prepare strategy checks
+    for i in range(0, len(responses), 2):
+        strategies = responses[i]
+        vault_name = responses[i + 1]
+        strategies_data.append((strategies, vault_name))
 
+    # Second batch: Check strategy assets and expiry
+    strategy_details = []
+    with client.batch_requests() as batch:
+        for strategies, _ in strategies_data:
+            for strategy_address in strategies:
+                strategy = client.eth.contract(
+                    address=strategy_address, abi=ABI_STRATEGY
+                )
+                batch.add(strategy.functions.totalAssets())
+                batch.add(strategy.functions.isExpired())
+                batch.add(strategy.functions.market())
+        responses = client.execute_batch(batch)
 
-def get_market_from_strategy(strategy_address, w3):
-    strategy = w3.eth.contract(address=strategy_address, abi=ABI_STRATEGY)
-    market_address = strategy.functions.market().call()
-    market = w3.eth.contract(address=market_address, abi=ABI_MARKET)
-    if market.functions.isExpired().call():
-        print(f"Market for {strategy_address} is expired")
-        return None, None
+    # Process strategy responses and prepare market checks
+    active_markets = []
+    idx = 0
+    for strategies, vault_name in strategies_data:
+        for strategy_address in strategies:
+            total_assets = responses[idx]
+            is_expired = responses[idx + 1]
+            market_address = responses[idx + 2]
 
-    expiry = market.functions.expiry().call()
-    expiry = datetime.datetime.fromtimestamp(expiry).strftime("%Y-%m-%d %H:%M:%S")
-    print(f"Market for {strategy_address}: {market_address}")
-    print(f"Expiry for {strategy_address}: {expiry}")
-    return market_address, expiry
+            if total_assets > 1e9 and not is_expired:
+                market = client.eth.contract(address=market_address, abi=ABI_MARKET)
+                active_markets.append((market_address, strategy_address, vault_name))
+            idx += 3
 
+    # Final batch: Check market expiry and get PT ratios
+    with client.batch_requests() as batch:
+        for market_address, _, _ in active_markets:
+            market = client.eth.contract(address=market_address, abi=ABI_MARKET)
+            batch.add(market.functions.isExpired())
+            batch.add(market.functions.expiry())
+            batch.add(oracle.functions.getPtToAssetRate(market_address, DURATION))
+        responses = client.execute_batch(batch)
 
-def get_data_for_chain(chain):
-    if chain == "mainnet":
-        w3 = Web3(Web3.HTTPProvider(PROVIDER_URL_MAINNET))
-        vaults = MAINNET_VAULTS
-    elif chain == "arbitrum":
-        w3 = Web3(Web3.HTTPProvider(PROVIDER_URL_ARB))
-        vaults = ARBITRUM_VAULTS
-    else:
-        raise ValueError("Invalid chain")
+    # Process final results
+    idx = 0
+    for market_address, strategy_address, vault_name in active_markets:
+        is_expired = responses[idx]
+        expiry = responses[idx + 1]
+        pt_ratio = responses[idx + 2] / 1e18
 
-    print(f"Processing {chain} assets...")
-    print(f"Vaults: {vaults}")
-
-    oracle = w3.eth.contract(address=ORACLE_ADDRESS, abi=ABI_ORACLE)
-    for vault in vaults:
-        strategies, name = get_strategies_from_vault(vault, w3)
-        for strategy in strategies:
-            market, expiry = get_market_from_strategy(strategy, w3)
-            if not market:
-                continue
-            ratio = get_ratio_for_market(market, oracle)
-            print(f"Market: {market}, Ratio: {ratio:.2f}")
-            if ratio < THRESHOLD_RATIO:
+        if not is_expired:
+            expiry_date = datetime.datetime.fromtimestamp(expiry).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            if pt_ratio < THRESHOLD_RATIO:
                 message = (
                     "🚨 **Pendle PT Ratio** 🚨\n"
-                    f"💎 Market: {market}\n"
-                    f"📊 PT to Asset Ratio: {ratio:.2f}\n"
-                    f"🌐 Chain: {chain}\n"
-                    f"🕒 Expiry: {expiry}\n"
-                    f"🏦 Vault: {name}"
+                    f"💎 Market: {market_address}\n"
+                    f"📊 PT to Asset Ratio: {pt_ratio:.2f}\n"
+                    f"🌐 Chain: {chain.name}\n"
+                    f"🕒 Expiry: {expiry_date}\n"
+                    f"🏦 Vault: {vault_name}"
                 )
                 send_telegram_message(message, PROTOCOL, False)
+        idx += 3
 
 
 def main():
-    get_data_for_chain("mainnet")
-    get_data_for_chain("arbitrum")
+    for chain in [Chain.MAINNET, Chain.ARBITRUM]:
+        print(f"Processing {chain.name} assets...")
+        process_assets(chain)
 
 
 if __name__ == "__main__":

--- a/pendle/main.py
+++ b/pendle/main.py
@@ -1,7 +1,7 @@
+import json, datetime
 from utils.web3_wrapper import ChainManager
 from utils.chains import Chain
 from utils.telegram import send_telegram_message
-import json, datetime
 
 # Constants
 DURATION = 1800  # 30 minutes
@@ -62,7 +62,6 @@ def process_assets(chain: Chain):
         strategies_data.append((strategies, vault_name))
 
     # Second batch: Check strategy assets and expiry
-    strategy_details = []
     with client.batch_requests() as batch:
         for strategies, _ in strategies_data:
             for strategy_address in strategies:

--- a/safe/main.py
+++ b/safe/main.py
@@ -167,11 +167,11 @@ def main():
             "base-main",
             "0xB9d4acf113a423Bc4A64110B8738a52E51C2AB38",
         ],  # pause guardian of comptroller contract
-        [
-            "USD0",
-            "mainnet",
-            "0x6e9d65eC80D69b1f508560Bc7aeA5003db1f7FB7",
-        ],  # USD0 protocol governance
+        # [
+        #     "USD0",
+        #     "mainnet",
+        #     "0x6e9d65eC80D69b1f508560Bc7aeA5003db1f7FB7",
+        # ],  # USD0 protocol governance
         # no active stargate strategies
         # ["STARGATE", "mainnet", "0x65bb797c2B9830d891D87288F029ed8dACc19705"],
         # ["STARGATE", "polygon-main", "0x47290DE56E71DC6f46C26e50776fe86cc8b21656"],

--- a/silo/ur_sniff.py
+++ b/silo/ur_sniff.py
@@ -1,6 +1,6 @@
+import json
 from utils.web3_wrapper import ChainManager
 from utils.chains import Chain
-import json
 from utils.telegram import send_telegram_message
 
 THRESHOLD_UR = 0.94
@@ -71,7 +71,7 @@ def process_assets(chain: Chain):
 
 
 def main():
-    for chain in ADDRESSES_BY_CHAIN.keys():
+    for chain in [Chain.ARBITRUM]:
         print(f"Processing {chain.name} Silos...")
         process_assets(chain)
 

--- a/spark/main.py
+++ b/spark/main.py
@@ -1,10 +1,7 @@
+import json
 from utils.web3_wrapper import ChainManager
 from utils.chains import Chain
-from dotenv import load_dotenv
-import os, json
 from utils.telegram import send_telegram_message
-
-load_dotenv()
 
 PROTOCOL = "SPARK"
 
@@ -79,27 +76,30 @@ def print_stuff(chain_name, token_name, ur):
 
 
 # Function to process assets for a specific network
-def process_assets(chain_name, addresses):
+def process_assets(chain, addresses):
     # Get Web3 client using ChainManager
-    client = ChainManager.get_client(Chain.MAINNET)
-
-    # Create batch request
-    batch = client.batch_requests()
+    client = ChainManager.get_client(chain)
 
     # Prepare all contracts and batch calls
-    contracts = []
-    for atoken_address, underlying_token_address in addresses:
-        atoken = client.get_contract(atoken_address, abi_atoken)
-        underlying_token = client.get_contract(underlying_token_address, abi_atoken)
-        contracts.append((atoken, underlying_token))
+    with client.batch_requests() as batch:
+        for atoken_address, underlying_token_address in addresses:
+            atoken = client.eth.contract(address=atoken_address, abi=abi_atoken)
+            underlying_token = client.eth.contract(
+                address=underlying_token_address, abi=abi_atoken
+            )
 
-        # Add all calls to the batch
-        batch.add(atoken.functions.totalSupply())
-        batch.add(underlying_token.functions.balanceOf(atoken_address))
-        batch.add(underlying_token.functions.symbol())
+            # Add all calls to the batch
+            batch.add(atoken.functions.totalSupply())
+            batch.add(underlying_token.functions.balanceOf(atoken_address))
+            batch.add(underlying_token.functions.symbol())
 
-    # Execute batch
-    responses = batch.execute()
+        # Execute all calls at once
+        responses = batch.execute()
+        expected_responses = len(addresses) * 3
+        if len(responses) != expected_responses:
+            raise ValueError(
+                f"Expected {expected_responses} responses from batch, got: {len(responses)}"
+            )
 
     # Process results
     expected_responses = len(addresses) * 3
@@ -120,13 +120,13 @@ def process_assets(chain_name, addresses):
         debt = ts - av
         ur = debt / ts if ts != 0 else 0
 
-        print_stuff(chain_name, token_name, ur)
+        print_stuff(chain.name, token_name, ur)
 
 
 # Main function
 def main():
     print("Processing Mainnet assets...")
-    process_assets("Mainnet", mainnet_addresses)
+    process_assets(Chain.MAINNET, mainnet_addresses)
 
 
 # Run the main function

--- a/spark/main.py
+++ b/spark/main.py
@@ -56,7 +56,7 @@ mainnet_addresses = [
 ]
 
 # TODO: Add different threshold UR's for each asset
-THRESHOLD_UR = 0.96
+THRESHOLD_UR = 0.99
 THRESHOLD_UR_NOTIFICATION = 0.99
 
 

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -11,6 +11,7 @@ nonces_filename = os.getenv("NONCE_FILENAME", "nonces.txt")
 morpho_filename = os.getenv("MORPHO_FILENAME", "cache-id.txt")
 # use the same cache file because it is run in the same hourly workflow
 
+
 def get_last_queued_id_from_file(protocol):
     return get_last_value_for_key_from_file(cache_filename, protocol)
 

--- a/utils/chains.py
+++ b/utils/chains.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+
+class Chain(Enum):
+    MAINNET = (1, "mainnet", "eth")
+    OPTIMISM = (10, "optimism", "op")
+    BASE = (8453, "base", "base")
+    ARBITRUM = (42161, "arbitrum", "arb")
+    POLYGON = (137, "polygon", "matic")
+
+    def __init__(self, chain_id: int, network_name: str, symbol: str):
+        self.chain_id = chain_id
+        self.network_name = network_name
+        self.symbol = symbol
+
+    @classmethod
+    def from_chain_id(cls, chain_id: int) -> "Chain":
+        for chain in cls:
+            if chain.chain_id == chain_id:
+                return chain
+        raise ValueError(f"Unknown chain_id: {chain_id}")
+
+    @classmethod
+    def from_name(cls, name: str) -> "Chain":
+        name = name.lower()
+        for chain in cls:
+            if chain.network_name == name:
+                return chain
+        raise ValueError(f"Unknown chain name: {name}")

--- a/utils/web3_wrapper.py
+++ b/utils/web3_wrapper.py
@@ -1,0 +1,135 @@
+from web3 import Web3
+from web3.providers.base import BaseProvider
+from web3.exceptions import ProviderConnectionError
+from web3.contract import Contract
+import time, os
+from dotenv import load_dotenv
+from typing import List, Dict, TypeVar, Callable
+from .chains import Chain
+
+load_dotenv()
+
+T = TypeVar("T")  # Generic type for return values
+
+
+class RetryProvider(BaseProvider):
+    def __init__(
+        self, providers: List[Web3.HTTPProvider], max_retries=3, backoff_factor=0.3
+    ):
+        self.providers = providers
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.current_provider_index = 0
+
+    def make_request(self, method, params):
+        retries = 0
+        last_error = None
+
+        while retries < self.max_retries:
+            current_provider = self.providers[self.current_provider_index]
+            try:
+                response = current_provider.make_request(method, params)
+                if "error" in response:
+                    raise ProviderConnectionError(response["error"])
+                return response
+            except (ProviderConnectionError, IOError) as e:
+                last_error = e
+                retries += 1
+                wait_time = self.backoff_factor * (2 ** (retries - 1))
+                print(
+                    f"Provider {self.current_provider_index + 1} failed with {e}. Retrying in {wait_time} seconds..."
+                )
+                time.sleep(wait_time)
+                self.current_provider_index = (self.current_provider_index + 1) % len(
+                    self.providers
+                )
+
+        raise ProviderConnectionError(
+            f"All providers failed after {self.max_retries} retries. Last error: {last_error}"
+        )
+
+
+class BatchRequest:
+    def __init__(self, web3_client: "Web3Client"):
+        self._web3_client = web3_client
+        self._calls = []
+
+    def add(self, contract_function):
+        """Add a contract function call to the batch"""
+        self._calls.append(contract_function)
+
+    def execute(self):
+        """Execute all calls in the batch with retry logic"""
+        results = []
+        for call in self._calls:
+            try:
+                result = self._web3_client.execute(call.call)
+                results.append(result)
+            except Exception as e:
+                print(f"Error in batch call: {e}")
+                results.append(None)
+        return results
+
+
+class Web3Client:
+    def __init__(self, chain: Chain):
+        self.chain = chain
+        self.w3 = self._initialize_web3()
+
+    def _initialize_web3(self) -> Web3:
+        """Initialize Web3 with retry provider for the specified chain"""
+        providers = self._get_providers()
+        retry_provider = RetryProvider(providers)
+        return Web3(retry_provider)
+
+    def _get_providers(self) -> List[Web3.HTTPProvider]:
+        """Get providers for the chain from environment variables"""
+        providers = []
+        # try to get the default provider
+        env_key = f"PROVIDER_URL_{self.chain.name.upper()}"
+        url = os.getenv(env_key)
+        if url:
+            providers.append(Web3.HTTPProvider(url))
+        #
+        for i in range(1, 3):
+            env_key = f"PROVIDER_URL_{self.chain.name.upper()}_{i}"
+            url = os.getenv(env_key)
+            if url:
+                providers.append(Web3.HTTPProvider(url))
+
+        if not providers:
+            raise ValueError(f"No providers found for chain {self.chain.name}")
+        return providers
+
+    def execute(self, operation: Callable[..., T], *args, **kwargs) -> T:
+        """Execute any Web3 operation with retry logic"""
+        try:
+            return operation(*args, **kwargs)
+        except Exception as e:
+            raise ProviderConnectionError(
+                f"Operation failed on {self.chain.name}: {str(e)}"
+            )
+
+    @property
+    def eth(self):
+        """Access to eth namespace"""
+        return self.w3.eth
+
+    def get_contract(self, address: str, abi: List[Dict]) -> Contract:
+        """Get contract instance"""
+        return self.w3.eth.contract(address=address, abi=abi)
+
+    def batch_requests(self) -> BatchRequest:
+        """Create a new batch request with retry logic"""
+        return BatchRequest(self)
+
+
+class ChainManager:
+    _instances: Dict[Chain, Web3Client] = {}
+
+    @classmethod
+    def get_client(cls, chain: Chain) -> Web3Client:
+        """Get or create Web3Client instance for specified chain"""
+        if chain not in cls._instances:
+            cls._instances[chain] = Web3Client(chain)
+        return cls._instances[chain]

--- a/utils/web3_wrapper.py
+++ b/utils/web3_wrapper.py
@@ -70,7 +70,7 @@ class MultiHTTPProvider(HTTPProvider, RetryProviders):
         providers = self._validate_urls(providers)
         RetryProviders.__init__(self, providers, max_retries, backoff_factor)
         self.request_kwargs = request_kwargs or {}
-        self.request_kwargs.setdefault("timeout", 1000)
+        self.request_kwargs.setdefault("timeout", 5000)
         super().__init__(
             endpoint_uri=self.endpoint_uri, request_kwargs=self.request_kwargs
         )
@@ -111,7 +111,7 @@ class Web3Client(RetryProviders):
         """Initialize Web3 with multi-provider setup"""
         provider_urls = self._get_provider_urls()
         provider = MultiHTTPProvider(
-            providers=provider_urls, max_retries=3, backoff_factor=1
+            providers=provider_urls, max_retries=3, backoff_factor=2
         )
         return Web3(provider)
 


### PR DESCRIPTION
⚠️ Add the following to environment secrets ⚠️ 
- `PROVIDER_URL_MAINNET_1`
- `PROVIDER_URL_MAINNET_2`
- `PROVIDER_URL_MAINNET_3`

These changes implement a retry mechanism for Web3 requests. After failed requests, the web3_wrapper switches providers from `PROVIDER_URL_MAINNET` to `PROVIDER_URL_MAINNET_1` and so on.
We can add providers for other chains, but we have only problems with failing requests on mainnet, lets define this for mainnet only, for a start.

Disable all monitoring on Optimism because we don't manage any vaults there.