### PR TITLE
feat(timelock): add Yearn TimelockController monitoring on 6 chains

### DIFF
--- a/timelock/README.md
+++ b/timelock/README.md
@@ -96,6 +96,12 @@ For complete field mapping details, see [`detils.md`](./detils.md).
 | [0x2e59a20f205bb85a89c53f1936454680651e618e](https://etherscan.io/address/0x2e59a20f205bb85a89c53f1936454680651e618e) | Mainnet | LIDO | Lido Timelock |
 | [0x2efff88747eb5a3ff00d4d8d0f0800e306c0426b](https://etherscan.io/address/0x2efff88747eb5a3ff00d4d8d0f0800e306c0426b) | Mainnet | MAPLE | Maple GovernorTimelock |
 | [0xf817cb3092179083c48c014688d98b72fb61464f](https://basescan.org/address/0xf817cb3092179083c48c014688d98b72fb61464f) | Base | LRT | superOETH Timelock |
+| [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://etherscan.io/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Mainnet | YEARN | Yearn TimelockController |
+| [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://basescan.org/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Base | YEARN | Yearn TimelockController |
+| [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://arbiscan.io/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Arbitrum | YEARN | Yearn TimelockController |
+| [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://polygonscan.com/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Polygon | YEARN | Yearn TimelockController |
+| 0x88ba032be87d5ef1fbe87336b7090767f367bf73 | Katana | YEARN | Yearn TimelockController |
+| [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://optimistic.etherscan.io/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Optimism | YEARN | Yearn TimelockController |
 
 ## How to Add a New Timelock
 

--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -54,10 +54,17 @@ TIMELOCK_LIST: list[TimelockConfig] = [
     TimelockConfig("0x2efff88747eb5a3ff00d4d8d0f0800e306c0426b", 1, "MAPLE", "Maple GovernorTimelock"),
     # Chain 8453 - Base
     TimelockConfig("0xf817cb3092179083c48c014688d98b72fb61464f", 8453, "LRT", "superOETH Timelock"),
+    # Yearn Timelock (0x88Ba032be87d5EF1fbE87336B7090767F367BF73) - all chains
+    TimelockConfig("0x88ba032be87d5ef1fbe87336b7090767f367bf73", 1, "YEARN", "Yearn TimelockController"),
+    TimelockConfig("0x88ba032be87d5ef1fbe87336b7090767f367bf73", 8453, "YEARN", "Yearn TimelockController"),
+    TimelockConfig("0x88ba032be87d5ef1fbe87336b7090767f367bf73", 42161, "YEARN", "Yearn TimelockController"),
+    TimelockConfig("0x88ba032be87d5ef1fbe87336b7090767f367bf73", 137, "YEARN", "Yearn TimelockController"),
+    TimelockConfig("0x88ba032be87d5ef1fbe87336b7090767f367bf73", 747474, "YEARN", "Yearn TimelockController"),
+    TimelockConfig("0x88ba032be87d5ef1fbe87336b7090767f367bf73", 10, "YEARN", "Yearn TimelockController"),
 ]
 
-# Lookup by lowercase address
-TIMELOCKS: dict[str, TimelockConfig] = {t.address: t for t in TIMELOCK_LIST}
+# Lookup by (lowercase address, chain_id) to support same address on multiple chains
+TIMELOCKS: dict[tuple[str, int], TimelockConfig] = {(t.address, t.chain_id): t for t in TIMELOCK_LIST}
 
 _logger = get_logger("timelock_alerts")
 
@@ -295,7 +302,8 @@ def process_events(events: list[dict], use_cache: bool) -> None:
         # so call order within batch operations is preserved
 
         timelock_addr = op_events[0]["timelockAddress"].lower()
-        timelock_info = TIMELOCKS.get(timelock_addr)
+        chain_id = int(op_events[0]["chainId"])
+        timelock_info = TIMELOCKS.get((timelock_addr, chain_id))
         if not timelock_info:
             _logger.warning("Unknown timelock address: %s", timelock_addr)
             continue


### PR DESCRIPTION
## Summary
- Add monitoring for Yearn timelock contract (`0x88Ba032be87d5EF1fbE87336B7090767F367BF73`) as `TimelockController` type on Mainnet, Base, Arbitrum, Polygon, Katana, and Optimism
- Fix `TIMELOCKS` lookup dict to use `(address, chain_id)` composite key instead of address-only, needed when the same contract exists on multiple chains
- Protocol set to `YEARN` for Telegram routing

## Dependencies
- Requires [chain-events/yearn-indexing-test](https://github.com/chain-events/yearn-indexing-test) to add the address to the Envio indexer config first
- First merge: https://github.com/chain-events/yearn-indexing-test/pull/9

## Test plan
- [x] Verify Envio indexer is updated and indexing events for the new address
- [x] Run `uv run timelock/timelock_alerts.py --no-cache --since-seconds 604800 --log-level DEBUG --protocol YEARN` to verify
- [x] Confirm `TELEGRAM_CHAT_ID_YEARN` is set in GitHub Actions secrets