### PR TITLE
feat(infinifi): add junior TVL vs risky farm exposure alert

### DIFF
--- a/infinifi/README.md
+++ b/infinifi/README.md
@@ -18,7 +18,7 @@ This folder contains monitoring scripts for the Infinifi protocol.
 - **Redemption Pressure**: Alert if `pending redemptions / liquid reserves` exceeds `80%`.
 - **Farm Allocation Shift**: Alert if any farm allocation ratio (`farm assets / total TVL`) changes by more than `FARM_RATIO_CHANGE_ALERT_THRESHOLD` versus cached ratio. Farms below 1% of total TVL are excluded.
 - **Farm Activation**: Alert if a farm previously at `0` cached ratio moves above `FARM_RATIO_ACTIVATION_ALERT_THRESHOLD` of total TVL.
-- **Junior TVL Below Risky Exposure**: Alert if junior TVL (locked iUSD) covers less than 80% of risky farm TVL. Risky farms are all farms NOT in the `SAFE_FARM_IDENTIFIERS` whitelist.
+- **Junior TVL Below Risky Exposure**: Alert if junior TVL (locked iUSD) covers less than 50% of risky farm TVL. Risky farms are all farms NOT in the `SAFE_FARM_IDENTIFIERS` whitelist.
 
 ### Alerts disabled ⚠️
 

--- a/infinifi/main.py
+++ b/infinifi/main.py
@@ -30,7 +30,7 @@ SAFE_FARM_IDENTIFIERS = [
     "fluid usdc",
     "euler sentora usdc",
 ]
-JUNIOR_RISKY_COVERAGE_MIN = 0.8
+JUNIOR_RISKY_COVERAGE_MIN = 0.5
 
 # API Configuration
 API_BASE_URL = "https://api.infinifi.xyz"


### PR DESCRIPTION
## Summary
- Adds alert when junior tranche TVL (locked iUSD) covers less than 50% of risky farm exposure
- Risky farms = all farms NOT in the safe farms whitelist (`SAFE_FARM_IDENTIFIERS`)
- Safe farms: Sentora PYUSD, sGHO, Maple, Cap, Aave Horizon, SyrupUSDC, AutoUSD, Spark sUSDC, Fluid USDC, Euler Sentora USDC
- Uses existing `send_breach_alert_once` / `clear_breach_state` pattern for spam-free alerting
- Alert message includes coverage percentage, shortfall amount, and per-farm breakdown

Closes #146

## Test plan
- [x] Verify API data parsing for `receipt.totalLockedNormalized` (junior TVL)
- [x] Verify safe farm matching against both `name` and `label` fields
- [x] Confirm alert fires when junior TVL < 50% of risky farm exposure
- [x] Confirm alert clears when junior TVL >= 50% of risky farm exposure
- [x] Validate Telegram message formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)