### PR TITLE
feat(maker): add DSPause timelock monitoring via Envio

### DIFF
--- a/maker/README.md
+++ b/maker/README.md
@@ -8,20 +8,15 @@
 
 Run: `python maker/proposals.py`
 
-### Tenderly Alerts
+### DSPause Timelock
 
-Tenderly alert for function [`plot()` called in DSPause](https://dashboard.tenderly.co/yearn/sam/alerts/rules/6c4b81c9-3130-4b3c-9356-15c9abc7b918) that schedules the plan (tx) that can be executed after a delay. A plan can be executed by anyone. A similar concept to Timelock controller. The minimum delay is set to [16 hours](https://etherscan.io/address/0xbe286431454714f511008713973d3b053a2d38f3#readContract#F2). Scheduled tx (spell) will only be executed Monday through Friday between 14:00 and 21:00 UTC.
+[DSPause](https://etherscan.io/address/0xbe286431454714f511008713973d3b053a2d38f3) schedules spells via `plot()` that can be executed after a delay. The minimum delay is [16 hours](https://etherscan.io/address/0xbe286431454714f511008713973d3b053a2d38f3#readContract#F2). Scheduled spells will only be executed Monday through Friday between 14:00 and 21:00 UTC.
 
-[PauseProxy](https://etherscan.io/address/0xbe8e3e3618f7474f8cb1d074a26affef007e98fb) controls [PSM USDC](https://etherscan.io/address/0x89B78CfA322F6C5dE0aBcEecab66Aee45393cC5A#readContract#F9), it can update the DAI/USDC rate by calling the function `file()`. Its [owner is DSPause contract](https://etherscan.io/address/0xbe8e3e3618f7474f8cb1d074a26affef007e98fb#readContract#F1), any update is covered with Tenderly alert specified above.
+Monitored via the internal [timelock monitoring system](../timelock/README.md) (`MAKER` protocol). Alerts are sent to the Maker Telegram channel when `plot()` is called.
 
-Upgradeable [sUSDS](https://etherscan.io/address/0xa3931d71877c0e7a3148cb7eb4463524fec27fbd) contract owner is also [set](https://etherscan.io/tx/0x4d4a0396ac55bd2113fe630efe9db0330043508e19ed93d8bb3973a5dda3727e#eventlog) to DSPause contract. This is the some for upgradeable token [USDS](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F), tx owner [set](https://etherscan.io/tx/0x3c9a2a60285c972bf103d29ffe97503b25c5dbcb130f2bd862749a69ec21098c#eventlog).
+[PauseProxy](https://etherscan.io/address/0xbe8e3e3618f7474f8cb1d074a26affef007e98fb) controls [PSM USDC](https://etherscan.io/address/0x89B78CfA322F6C5dE0aBcEecab66Aee45393cC5A#readContract#F9), it can update the DAI/USDC rate by calling the function `file()`. Its [owner is DSPause contract](https://etherscan.io/address/0xbe8e3e3618f7474f8cb1d074a26affef007e98fb#readContract#F1), any update is covered by the timelock alert.
 
-To get the proposal data from the received alert:
-
-1. see the tx from alert on [Tenderly](https://dashboard.tenderly.co/yearn/sam/tx/mainnet/0x4d84206c92894f4c4b5865d9c85f42105e5655d4a9415f799867a67ea3686c39)
-2. get [DssSpell address](https://dashboard.tenderly.co/yearn/sam/tx/mainnet/0x4d84206c92894f4c4b5865d9c85f42105e5655d4a9415f799867a67ea3686c39?trace=0.1)
-3. check proposals on [Maker DAO voting site](https://vote.makerdao.com/executive), after rebranding use [SKY DAO voting site](https://vote.sky.money/executive)
-4. [match proposal with spell address](https://vote.makerdao.com/executive/template-executive-vote-lite-psm-usdc-a-phase-2-setup-august-22-2024) with DssSpell address from tx
+Upgradeable [sUSDS](https://etherscan.io/address/0xa3931d71877c0e7a3148cb7eb4463524fec27fbd) contract owner is also [set](https://etherscan.io/tx/0x4d4a0396ac55bd2113fe630efe9db0330043508e19ed93d8bb3973a5dda3727e#eventlog) to DSPause contract. This is the same for upgradeable token [USDS](https://etherscan.io/address/0xdC035D45d973E3EC169d2276DDab16f1e407384F), tx owner [set](https://etherscan.io/tx/0x3c9a2a60285c972bf103d29ffe97503b25c5dbcb130f2bd862749a69ec21098c#eventlog).
 
 [Governance DSPause module docs](https://docs.makerdao.com/smart-contract-modules/governance-module/pause-detailed-documentation).
 

--- a/timelock/README.md
+++ b/timelock/README.md
@@ -1,6 +1,6 @@
 # Timelock Monitoring
 
-Monitors all timelock contract types (TimelockController, Aave, Compound, Puffer, Lido, Maple) and sends Telegram alerts to protocol-specific channels.
+Monitors all timelock contract types (TimelockController, Aave, Compound, Puffer, Lido, Maple, Maker) and sends Telegram alerts to protocol-specific channels.
 
 ## How It Works
 
@@ -13,7 +13,7 @@ The script runs [hourly via GitHub Actions](../.github/workflows/hourly.yml).
 
 ## GraphQL Schema
 
-The script queries the unified `TimelockEvent` type from the Envio indexer. The query fetches all timelock types (TimelockController, Aave, Compound, Puffer, Lido, Maple) for monitored addresses.
+The script queries the unified `TimelockEvent` type from the Envio indexer. The query fetches all timelock types (TimelockController, Aave, Compound, Puffer, Lido, Maple, Maker) for monitored addresses.
 
 ### Query Structure
 
@@ -58,7 +58,7 @@ The `TimelockEvent` type includes fields that vary by timelock type:
 **Common fields (all types):**
 - **`id`** - Unique identifier: `${chainId}_${blockNumber}_${logIndex}`
 - **`timelockAddress`** - Address of the timelock contract
-- **`timelockType`** - Type discriminator: `"TimelockController"`, `"Aave"`, `"Compound"`, `"Puffer"`, `"Lido"`, or `"Maple"`
+- **`timelockType`** - Type discriminator: `"TimelockController"`, `"Aave"`, `"Compound"`, `"Puffer"`, `"Lido"`, `"Maple"`, or `"Maker"`
 - **`eventName`** - Original event name (e.g., `"CallScheduled"`, `"ProposalQueued"`, `"QueueTransaction"`, etc.)
 - **`chainId`** - Chain ID (1 for Mainnet, 8453 for Base, etc.)
 - **`blockNumber`** - Block number where the event was emitted
@@ -73,6 +73,7 @@ The `TimelockEvent` type includes fields that vary by timelock type:
 - **Puffer**: `target`, `data`, `delay` (absolute timestamp/lockedUntil), `operationId` (txHash)
 - **Lido**: `creator`, `metadata`, `operationId` (voteId)
 - **Maple**: `delay` (absolute timestamp/delayedUntil), `operationId` (proposalId)
+- **Maker**: `target` (spell address), `delay` (absolute timestamp/eta), `creator` (caller), `operationId` (txHash)
 
 For complete field mapping details, see [`detils.md`](./detils.md).
 
@@ -95,6 +96,7 @@ For complete field mapping details, see [`detils.md`](./detils.md).
 | [0x3c28b7c7ba1a1f55c9ce66b263b33b204f2126ea](https://etherscan.io/address/0x3c28b7c7ba1a1f55c9ce66b263b33b204f2126ea) | Mainnet | LRT | Puffer Timelock |
 | [0x2e59a20f205bb85a89c53f1936454680651e618e](https://etherscan.io/address/0x2e59a20f205bb85a89c53f1936454680651e618e) | Mainnet | LIDO | Lido Timelock |
 | [0x2efff88747eb5a3ff00d4d8d0f0800e306c0426b](https://etherscan.io/address/0x2efff88747eb5a3ff00d4d8d0f0800e306c0426b) | Mainnet | MAPLE | Maple GovernorTimelock |
+| [0xbe286431454714f511008713973d3b053a2d38f3](https://etherscan.io/address/0xbe286431454714f511008713973d3b053a2d38f3) | Mainnet | MAKER | Maker DSPause |
 | [0xf817cb3092179083c48c014688d98b72fb61464f](https://basescan.org/address/0xf817cb3092179083c48c014688d98b72fb61464f) | Base | LRT | superOETH Timelock |
 | [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://etherscan.io/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Mainnet | YEARN | Yearn TimelockController |
 | [0x88ba032be87d5ef1fbe87336b7090767f367bf73](https://basescan.org/address/0x88ba032be87d5ef1fbe87336b7090767f367bf73) | Base | YEARN | Yearn TimelockController |
@@ -190,4 +192,4 @@ The script stores the latest processed `blockTimestamp` in `cache-id.txt` under 
 
 ## Schema Details
 
-For comprehensive information about the unified `TimelockEvent` schema, including field mappings for all supported timelock types (TimelockController, Aave, Compound, Puffer, Lido, Maple), see [`detils.md`](./detils.md).
+For comprehensive information about the unified `TimelockEvent` schema, including field mappings for all supported timelock types (TimelockController, Aave, Compound, Puffer, Lido, Maple, Maker), see [`detils.md`](./detils.md).

--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -52,6 +52,7 @@ TIMELOCK_LIST: list[TimelockConfig] = [
     TimelockConfig("0x3c28b7c7ba1a1f55c9ce66b263b33b204f2126ea", 1, "LRT", "Puffer Timelock"),
     TimelockConfig("0x2e59a20f205bb85a89c53f1936454680651e618e", 1, "LIDO", "Lido Timelock"),
     TimelockConfig("0x2efff88747eb5a3ff00d4d8d0f0800e306c0426b", 1, "MAPLE", "Maple GovernorTimelock"),
+    TimelockConfig("0xbe286431454714f511008713973d3b053a2d38f3", 1, "MAKER", "Maker DSPause"),
     # Chain 8453 - Base
     TimelockConfig("0xf817cb3092179083c48c014688d98b72fb61464f", 8453, "LRT", "superOETH Timelock"),
     # Yearn Timelock (0x88Ba032be87d5EF1fbE87336B7090767F367BF73) - all chains
@@ -170,7 +171,7 @@ def _format_delay_info(delay: int | None, timelock_type: str) -> str | None:
         return None
 
     delay_val = int(delay)
-    if timelock_type in ("Compound", "Puffer", "Maple"):
+    if timelock_type in ("Compound", "Puffer", "Maple", "Maker"):
         # Absolute timestamp
         relative = delay_val - int(time.time())
         if relative > 0:
@@ -256,7 +257,7 @@ def build_alert_message(events: list[dict], timelock_info: TimelockConfig) -> st
     elif timelock_type == "Maple":
         lines.append(f"🆔 Proposal: {first.get('operationId') or ''}")
 
-    elif timelock_type in ("TimelockController", "Compound", "Puffer"):
+    elif timelock_type in ("TimelockController", "Compound", "Puffer", "Maker"):
         for event in events:
             lines.extend(_build_call_info(event, explorer, len(events) > 1))
 


### PR DESCRIPTION
## Summary

- Add Maker DSPause (`0xbe286431454714f511008713973d3b053a2d38f3`) to the internal Envio-based timelock monitoring system, replacing Tenderly alerts
- Handle `Maker` timelock type with absolute timestamp delay (eta) and target/data call info display
- Update maker and timelock READMEs to reflect the transition

Closes #169

## Dependencies

Requires the Envio indexer PR to be deployed first: https://github.com/chain-events/yearn-indexing-test/pull/12

## Test plan

- [x] Deploy indexer PR (chain-events/yearn-indexing-test#12) and verify events appear in GraphQL
- [ ] Run: `uv run timelock/timelock_alerts.py --no-cache --since-seconds 604800 --protocol MAKER --log-level DEBUG`
- [ ] Verify Telegram alert is sent to the MAKER channel with correct format
- [ ] Disable Tenderly alert rule after confirming internal monitoring works

🤖 Generated with [Claude Code](https://claude.com/claude-code)