### PR TITLE
fix(morpho): handle Telegram errors in error notifications

### DIFF
--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -59,12 +59,13 @@ def send_telegram_message(
         return
 
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
-    payload = {
+    payload: dict[str, object] = {
         "chat_id": chat_id,
         "text": message,
-        "parse_mode": "Markdown" if not plain_text else None,
         "disable_notification": disable_notification,
     }
+    if not plain_text:
+        payload["parse_mode"] = "Markdown"
 
     try:
         response = requests.post(url, json=payload, timeout=10)


### PR DESCRIPTION
## Summary
- Add `send_telegram_message_safe` wrapper to `utils/telegram.py` that catches `TelegramError` and logs instead of raising
- Use the safe wrapper in `morpho/markets.py` and `morpho/markets_graph.py` error handlers so the script doesn't crash when both the Morpho API and Telegram fail

Closes #180

## Test plan
- [ ] Verify morpho/markets.py gracefully handles Morpho API 504 + Telegram 400 without crashing
- [ ] Verify morpho/markets_graph.py has the same safe behavior
- [ ] Confirm normal Telegram notifications (non-error paths) still raise on failure as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)