### PR TITLE
chore: add cbDOGE/USDC market to morpho risk 3

### DIFF
--- a/morpho/markets.py
+++ b/morpho/markets.py
@@ -319,6 +319,7 @@ MARKETS_RISK_3 = {
         "0xfdfecf85a4dd90a7637ae2aaf28b35061166f0e62bfc714c565eed9f7e959783",  # cbXRP/USDC -> lltv 77%, oracle: Chainlink XRP/USD, Higher LLTV.
         "0xdc69cf2caae7b7d1783fb5a9576dc875888afad17ab3d1a3fc102f741441c165",  # rETH/WETH -> lltv 94.5%, oracle: Chainlink rETH/ETH, high risk oracle
         "0x0103cbcd14c690f68a91ec7c84607153311e9954c94ac6eac06c9462db3fabb6",  # rETH/EURC -> lltv 94.5%, oracle: Chainlink rETH/ETH, high risk oracle
+        "0x73527ddd796e6d4f48387adaae36f6f3d49d606d7f2a15eb0c931416a58875d8",  # cbDOGE/USDC -> lltv 62.5%, oracle: Chainlink DOGE/USD
     ],
     Chain.KATANA: [
         "0xd8a93a4cd16f843c385391e208a9a9f2fd75aedfcca05e4810e5fbfcaa6baec6",  # wsrUSD/vbUSDC -> lltv 91.5%, oracle: API3 wsrUSD/rUSD Exchange Rate, rUSD = vbUSDC.


### PR DESCRIPTION
## Summary
- Add [cbDOGE/USDC market](https://app.morpho.org/base/market/0x73527ddd796e6d4f48387adaae36f6f3d49d606d7f2a15eb0c931416a58875d8) on Base to `MARKETS_RISK_3`
- lltv 62.5%, oracle: Chainlink DOGE/USD

## Test plan
- [ ] Verify market appears in monitoring output for Base vaults allocating to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)