### PR TITLE
feat: include alert message in emergency dispatch payload

### DIFF
--- a/infinifi/main.py
+++ b/infinifi/main.py
@@ -223,7 +223,6 @@ def main():
                 and last_reserves >= LIQUID_RESERVES_THRESHOLD
             ):
                 msg = f"📉 *Infinifi Liquid Reserves Alert*\n\nReserves dropped below ${LIQUID_RESERVES_THRESHOLD:,.0f}: ${liquid_reserves:,.2f}"
-                # TODO: add hook data
                 send_alert(Alert(AlertSeverity.HIGH, msg, PROTOCOL))
 
             write_last_value_to_file(cache_filename, cache_key_reserves, liquid_reserves)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -361,8 +361,9 @@ class TestDispatch(unittest.TestCase):
         self.assertEqual(payload["event_type"], "emergency_withdrawal")
         self.assertEqual(payload["client_payload"]["protocol"], "infinifi")
         self.assertEqual(payload["client_payload"]["severity"], "HIGH")
-        # Payload should only contain protocol and severity (no markets/vault/chain)
-        self.assertEqual(set(payload["client_payload"].keys()), {"protocol", "severity"})
+        self.assertEqual(payload["client_payload"]["message"], "Reserves low")
+        # Payload should only contain protocol, severity, and message (no markets/vault/chain)
+        self.assertEqual(set(payload["client_payload"].keys()), {"protocol", "severity", "message"})
 
         # Verify auth header
         headers = call_kwargs["headers"]

--- a/utils/dispatch.py
+++ b/utils/dispatch.py
@@ -88,6 +88,7 @@ def dispatch_emergency_withdrawal(alert: Alert) -> None:
         "client_payload": {
             "protocol": alert.protocol,
             "severity": alert.severity.value,
+            "message": alert.message,
         },
     }
 


### PR DESCRIPTION
## Summary

Forwards `alert.message` as a new `client_payload.message` field on the `emergency_withdrawal` repository_dispatch, so the receiving [liquidity-monitoring workflow](https://github.com/tapired/liquidity-monitoring/pull/212) can attach context to the HIGH-severity PR body / CRITICAL commit body.

- `utils/dispatch.py` — adds `"message": alert.message` to the dispatched payload
- `tests/test_utils.py` — updates `test_dispatch_sends_correct_payload` to assert the new field
- `infinifi/main.py` — removes a now-obsolete `# TODO: add hook data` comment (the alert message is the hook data)

No call-site changes needed: every existing HIGH/CRITICAL alert in the dispatchable protocols (`cap`, `infinifi`, `maple`, `origin`, `usdai`, `ethena`, `ethplus`) already constructs `Alert(...)` with a descriptive message that flows through automatically.

## Test plan

- [x] `uv run pytest tests/test_utils.py -k Dispatch` — all 12 dispatch tests pass
- [x] `uv run ruff check .` and `uv run ruff format --check .` — clean
- [ ] After merge: trigger a HIGH dispatch and confirm the resulting PR body includes a `**Message:**` section with the alert text
- [ ] After merge: trigger a CRITICAL dispatch and confirm `git log` on the receiving repo's main shows the alert text in the commit body

🤖 Generated with [Claude Code](https://claude.com/claude-code)