### PR TITLE
chore: deprecate silo monitoring and lower infinifi farm shift alert

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -27,7 +27,6 @@ jobs:
         lrt-pegs/origin_protocol.py
         # euler/markets.py
         infinifi/main.py
-        # silo/ur_sniff.py
         usdai/main.py
         usdai/large_mints.py
         yearn/alert_large_flows.py

--- a/infinifi/main.py
+++ b/infinifi/main.py
@@ -345,7 +345,7 @@ def main():
 
                 send_alert(
                     Alert(
-                        AlertSeverity.MEDIUM,
+                        AlertSeverity.LOW,
                         "*Infinifi Farm Allocation Shift Alert*\n\n"
                         "Farm allocation ratio changed by more than 10% vs previous run:\n" + "\n".join(moved_lines),
                         PROTOCOL,

--- a/safe/main.py
+++ b/safe/main.py
@@ -57,9 +57,6 @@ PROXY_UPGRADE_SIGNATURES = [
 
 # combined addresses, add more addresses if needed, last item is optional for additional info message
 ALL_SAFE_ADDRESSES = [
-    ["SILO", "mainnet", "0xE8e8041cB5E3158A0829A19E014CA1cf91098554"],
-    # ["SILO", "optimism-main", "0x468CD12aa9e9fe4301DB146B0f7037831B52382d"],
-    ["SILO", "arbitrum-main", "0x865A1DA42d512d8854c7b0599c962F67F5A5A9d9"],
     [
         "LIDO",
         "mainnet",


### PR DESCRIPTION
## Summary
- Deprecate silo monitoring: remove `silo/ur_sniff.py` from the hourly workflow and drop SILO multisigs from the safe transaction watcher.
- Lower the infinifi *Farm Allocation Shift Alert* from `MEDIUM` to `LOW` to reduce noise from routine reallocations.

## Test plan
- [ ] CI passes on this branch
- [ ] Confirm next hourly run no longer schedules `silo/ur_sniff.py`
- [ ] Confirm safe watcher no longer reports SILO multisigs
- [ ] Confirm next infinifi farm-shift alert dispatches at low severity