### PR TITLE
feat(safe): handle Safe multisend / delegatecall in AI explainer

### DIFF
--- a/safe/main.py
+++ b/safe/main.py
@@ -5,13 +5,14 @@ import time
 import requests
 from dotenv import load_dotenv
 
+from safe.multisend import build_context_note, extract_inner_calls, safe_utility_label
 from safe.specific import handle_pendle
 from utils.cache import (
     get_last_executed_nonce_from_file,
     write_last_executed_nonce_to_file,
 )
 from utils.chains import safe_network_to_chain_id
-from utils.llm.ai_explainer import explain_transaction, format_explanation_line
+from utils.llm.ai_explainer import explain_batch_transaction, explain_transaction, format_explanation_line
 from utils.logging import get_logger
 from utils.telegram import send_telegram_message
 
@@ -243,6 +244,56 @@ def get_safe_url(safe_address: str, network_name: str) -> str:
     return f"{SAFE_WEBSITE_URL}{safe_address_network_prefix[network_name]}:{safe_address}"
 
 
+def _explain_safe_tx(
+    tx: dict,
+    target: str,
+    hex_data: str,
+    chain_id: int,
+    protocol: str,
+    safe_address: str,
+    additional_info: str | None,
+):
+    """Pick the right AI explainer path for a Safe transaction.
+
+    Safe txs with operation=DELEGATECALL into a multisend utility can't be
+    modeled by our plain-CALL Tenderly simulator. Route them to the batch
+    explainer (one call per inner tx) with simulation skipped, and feed the
+    LLM a context note describing the delegated-execution semantics.
+    """
+    operation = int(tx.get("operation", 0) or 0)
+    inner_calls = extract_inner_calls(tx) if operation == 1 else []
+
+    if inner_calls:
+        context_note = build_context_note(tx, safe_address)
+        utility_label = safe_utility_label(target)
+        label = utility_label or (additional_info or "")
+        return explain_batch_transaction(
+            calls=inner_calls,
+            chain_id=chain_id,
+            protocol=protocol,
+            label=label,
+            from_address=safe_address,
+            skip_simulation=True,
+            context_note=context_note,
+        )
+
+    # Non-multisend DELEGATECALLs (rare): skip sim but still try to explain.
+    # Plain CALL txs: behave exactly as before.
+    skip_sim = operation == 1
+    context_note = build_context_note(tx, safe_address) if skip_sim else ""
+    return explain_transaction(
+        target=target,
+        calldata=hex_data,
+        chain_id=chain_id,
+        value=int(tx.get("value", 0)),
+        protocol=protocol,
+        label=additional_info or "",
+        from_address=safe_address,
+        skip_simulation=skip_sim,
+        context_note=context_note,
+    )
+
+
 def check_for_pending_transactions(safe_address: str, network_name: str, protocol: str) -> None:
     pending_transactions = get_pending_transactions(safe_address, network_name)
 
@@ -298,14 +349,14 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
             if hex_data and len(hex_data) >= 10:
                 chain_id = safe_network_to_chain_id(network_name)
                 try:
-                    explanation = explain_transaction(
+                    explanation = _explain_safe_tx(
+                        tx=tx,
                         target=target_contract,
-                        calldata=hex_data,
+                        hex_data=hex_data,
                         chain_id=chain_id,
-                        value=int(tx.get("value", 0)),
                         protocol=protocol,
-                        label=additional_info or "",
-                        from_address=safe_address,
+                        safe_address=safe_address,
+                        additional_info=additional_info,
                     )
                     if explanation:
                         message += format_explanation_line(explanation)

--- a/safe/multisend.py
+++ b/safe/multisend.py
@@ -1,0 +1,82 @@
+"""Helpers for Safe transactions that target the canonical multisend utility.
+
+When a Safe executes a batch via MultiSendCallOnly (or legacy MultiSend), the
+outer call is a DELEGATECALL from the Safe — our plain-CALL Tenderly simulator
+can't model that, and the Safe API already provides the decoded inner calls in
+``dataDecoded.parameters[0].valueDecoded``. We use that decoded form directly
+rather than decoding the packed `multiSend(bytes)` payload ourselves.
+"""
+
+# Canonical Safe utility contract addresses are identical across all chains
+# Safe is deployed on. Source: https://github.com/safe-global/safe-deployments
+_SAFE_UTILS: dict[str, str] = {
+    "0x40a2accbd92bca938b02010e17a5b8929b49130d": "Safe MultiSendCallOnly",
+    "0x9641d764fc13c8b624c04430c7356c1c7c8102e2": "Safe MultiSendCallOnly v1.4.1",
+    "0x38869bf66a61cf6bdb996a6ae40d5853fd43b526": "Safe MultiSend (legacy, permits nested DELEGATECALL)",
+    "0x998739bfdaadde7c933b942a68053933098f9eda": "Safe MultiSend v1.3.0",
+    "0xa238cbeb142c10ef7ad8442c6d1f9e89e07e7761": "Safe MultiSend v1.4.1",
+    "0xd53cd0ab83d845ac265be939c57f53ad838012c9": "Safe SignMessageLib",
+}
+
+
+def safe_utility_label(address: str) -> str:
+    """Return a human-readable label for a canonical Safe utility, or ""."""
+    return _SAFE_UTILS.get(address.lower(), "")
+
+
+def extract_inner_calls(tx: dict) -> list[dict[str, str]]:
+    """Pull the multisend inner calls out of a Safe transaction.
+
+    Expects ``tx['dataDecoded']['parameters'][0]['valueDecoded']`` to contain a
+    list of inner txs (the Safe API's decoded multiSend payload). Returns a list
+    of ``{target, data, value}`` dicts suitable for ``explain_batch_transaction``.
+    Returns ``[]`` when the structure isn't present.
+    """
+    data_decoded = tx.get("dataDecoded") or {}
+    if data_decoded.get("method") not in {"multiSend"}:
+        return []
+
+    params = data_decoded.get("parameters") or []
+    if not params:
+        return []
+
+    value_decoded = params[0].get("valueDecoded")
+    if not isinstance(value_decoded, list):
+        return []
+
+    calls: list[dict[str, str]] = []
+    for inner in value_decoded:
+        to = inner.get("to")
+        if not to:
+            continue
+        calls.append(
+            {
+                "target": to,
+                "data": inner.get("data") or "0x",
+                "value": str(inner.get("value", "0")),
+            }
+        )
+    return calls
+
+
+def build_context_note(tx: dict, safe_address: str) -> str:
+    """Describe the outer-call semantics so the LLM doesn't have to guess.
+
+    Returns a short note that explains DELEGATECALL semantics and identifies
+    the multisend target when applicable. Empty string for plain CALLs.
+    """
+    operation = int(tx.get("operation", 0) or 0)
+    if operation != 1:
+        return ""
+
+    target = tx.get("to") or ""
+    label = safe_utility_label(target)
+    lines = [
+        f"Outer call is DELEGATECALL from the Safe ({safe_address}) into {target}"
+        + (f" ({label})" if label else "")
+        + ".",
+        f"Inner calls execute in the Safe's own storage context: msg.sender = {safe_address}.",
+        "Tenderly simulation was skipped because our simulator only models plain CALL "
+        "and would produce spurious revert info for this delegated flow.",
+    ]
+    return "\n".join(lines)

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -175,6 +175,89 @@ class TestBuildPromptWithSourceContext(unittest.TestCase):
         self.assertIn("Do NOT assume the semantic meaning", result)
         self.assertIn("source context", result.lower())
 
+    def test_context_note_appears_in_prompt(self) -> None:
+        calls = [DecodedCall(function_name="swapOwner", signature="swapOwner(address,address,address)")]
+        result = _build_prompt(
+            target="0xT",
+            value=0,
+            decoded_calls=calls,
+            simulation=None,
+            context_note="Outer call is DELEGATECALL from the Safe.",
+        )
+        self.assertIn("--- Execution Context ---", result)
+        self.assertIn("DELEGATECALL from the Safe", result)
+
+
+class TestSkipSimulation(unittest.TestCase):
+    """Tests for skip_simulation flag."""
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction")
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    def test_explain_transaction_skips_tenderly_when_flag_set(
+        self,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(function_name="pause", signature="pause()")
+        mock_provider = MagicMock()
+        mock_provider.complete.return_value = "TLDR: paused"
+        mock_provider.model_name = "test-model"
+        mock_get_provider.return_value = mock_provider
+
+        explain_transaction(
+            target="0xT",
+            calldata="0x8456cb59",
+            chain_id=1,
+            skip_simulation=True,
+            context_note="delegated",
+        )
+
+        mock_simulate.assert_not_called()
+        prompt = mock_provider.complete.call_args[0][0]
+        self.assertIn("--- Execution Context ---", prompt)
+        self.assertIn("delegated", prompt)
+        self.assertNotIn("--- Simulation Results ---", prompt)
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction")
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    def test_explain_batch_transaction_skips_tenderly_when_flag_set(
+        self,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(
+            function_name="swapOwner", signature="swapOwner(address,address,address)"
+        )
+        mock_provider = MagicMock()
+        mock_provider.complete.return_value = "TLDR: swap"
+        mock_provider.model_name = "test-model"
+        mock_get_provider.return_value = mock_provider
+
+        from utils.llm.ai_explainer import explain_batch_transaction
+
+        explain_batch_transaction(
+            calls=[
+                {"target": "0xSafe", "data": "0xe318b52b" + "00" * 96, "value": "0"},
+                {"target": "0xSafe", "data": "0xe318b52b" + "11" * 96, "value": "0"},
+            ],
+            chain_id=1,
+            skip_simulation=True,
+            context_note="delegated batch",
+        )
+
+        mock_simulate.assert_not_called()
+        prompt = mock_provider.complete.call_args[0][0]
+        self.assertIn("delegated batch", prompt)
+        self.assertNotIn("--- Simulation Results ---", prompt)
+
 
 class TestExplainTransaction(unittest.TestCase):
     """Tests for explain_transaction."""

--- a/tests/test_safe_multisend.py
+++ b/tests/test_safe_multisend.py
@@ -1,0 +1,124 @@
+"""Tests for safe/multisend.py."""
+
+import unittest
+
+from safe.multisend import build_context_note, extract_inner_calls, safe_utility_label
+
+
+class TestSafeUtilityLabel(unittest.TestCase):
+    def test_known_multisend_call_only(self) -> None:
+        self.assertEqual(
+            safe_utility_label("0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"),
+            "Safe MultiSendCallOnly",
+        )
+
+    def test_case_insensitive(self) -> None:
+        self.assertEqual(
+            safe_utility_label("0x40a2accbd92bca938b02010e17a5b8929b49130d"),
+            "Safe MultiSendCallOnly",
+        )
+
+    def test_unknown_address(self) -> None:
+        self.assertEqual(safe_utility_label("0x000000000000000000000000000000000000dead"), "")
+
+
+class TestExtractInnerCalls(unittest.TestCase):
+    def test_decodes_two_inner_swap_owner_calls(self) -> None:
+        # Shape mirrors the Safe Transaction Service API response for the
+        # Lido nonce-10 swapOwner batch.
+        tx = {
+            "to": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D",
+            "operation": 1,
+            "dataDecoded": {
+                "method": "multiSend",
+                "parameters": [
+                    {
+                        "name": "transactions",
+                        "valueDecoded": [
+                            {
+                                "operation": 0,
+                                "to": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C",
+                                "value": "0",
+                                "data": "0xe318b52b" + "00" * 96,
+                            },
+                            {
+                                "operation": 0,
+                                "to": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C",
+                                "value": "0",
+                                "data": "0xe318b52b" + "11" * 96,
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+        calls = extract_inner_calls(tx)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["target"], "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C")
+        self.assertTrue(calls[0]["data"].startswith("0xe318b52b"))
+        self.assertEqual(calls[0]["value"], "0")
+
+    def test_non_multisend_returns_empty(self) -> None:
+        tx = {
+            "to": "0xSomeContract",
+            "operation": 0,
+            "dataDecoded": {"method": "swapOwner", "parameters": []},
+        }
+        self.assertEqual(extract_inner_calls(tx), [])
+
+    def test_missing_data_decoded_returns_empty(self) -> None:
+        self.assertEqual(extract_inner_calls({"to": "0xFoo", "operation": 1}), [])
+
+    def test_value_decoded_not_a_list_returns_empty(self) -> None:
+        tx = {
+            "dataDecoded": {
+                "method": "multiSend",
+                "parameters": [{"valueDecoded": None}],
+            }
+        }
+        self.assertEqual(extract_inner_calls(tx), [])
+
+    def test_skips_inner_calls_without_target(self) -> None:
+        tx = {
+            "dataDecoded": {
+                "method": "multiSend",
+                "parameters": [
+                    {
+                        "valueDecoded": [
+                            {"operation": 0, "to": None, "value": "0", "data": "0x"},
+                            {"operation": 0, "to": "0xABC", "value": "0", "data": "0x"},
+                        ]
+                    }
+                ],
+            }
+        }
+        calls = extract_inner_calls(tx)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["target"], "0xABC")
+
+
+class TestBuildContextNote(unittest.TestCase):
+    def test_delegatecall_into_known_multisend(self) -> None:
+        tx = {"to": "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D", "operation": 1}
+        note = build_context_note(tx, "0xSafe123")
+        self.assertIn("DELEGATECALL", note)
+        self.assertIn("0xSafe123", note)
+        self.assertIn("Safe MultiSendCallOnly", note)
+        self.assertIn("simulation was skipped", note.lower())
+
+    def test_delegatecall_into_unknown_target(self) -> None:
+        tx = {"to": "0xCustomDelegated", "operation": 1}
+        note = build_context_note(tx, "0xSafe")
+        self.assertIn("DELEGATECALL", note)
+        self.assertNotIn("MultiSend", note)
+
+    def test_plain_call_returns_empty(self) -> None:
+        tx = {"to": "0xFoo", "operation": 0}
+        self.assertEqual(build_context_note(tx, "0xSafe"), "")
+
+    def test_missing_operation_returns_empty(self) -> None:
+        self.assertEqual(build_context_note({"to": "0xFoo"}, "0xSafe"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -162,6 +162,7 @@ def _build_prompt(
     label: str = "",
     proxy_upgrade_info: str = "",
     source_contexts: list[SourceContext] | None = None,
+    context_note: str = "",
 ) -> str:
     """Build the full prompt for the LLM."""
     parts: list[str] = [SYSTEM_PROMPT, ""]
@@ -173,6 +174,9 @@ def _build_prompt(
     parts.append(f"Target: {target}")
     if value > 0:
         parts.append(f"ETH Value: {value / 1e18:.6f} ETH")
+
+    if context_note:
+        parts.append(f"\n--- Execution Context ---\n{context_note}")
 
     parts.append(f"\n--- Decoded Calldata ---\n{_format_decoded_calls(decoded_calls)}")
 
@@ -248,6 +252,8 @@ def explain_transaction(
     protocol: str = "",
     label: str = "",
     from_address: str = "0x0000000000000000000000000000000000000000",
+    skip_simulation: bool = False,
+    context_note: str = "",
 ) -> Explanation | None:
     """Generate an AI explanation for a governance transaction.
 
@@ -262,6 +268,12 @@ def explain_transaction(
         protocol: Protocol name for context (e.g. "AAVE").
         label: Human-readable label for the contract.
         from_address: Sender address for simulation.
+        skip_simulation: If True, do not call Tenderly. Use when the caller knows
+            our plain-CALL simulator can't model the real execution (e.g. Safe
+            DELEGATECALL into MultiSendCallOnly).
+        context_note: Optional preamble injected into the prompt to give the LLM
+            context that isn't in the calldata (e.g. "this is delegated from
+            a Safe; msg.sender of inner calls is the Safe itself").
 
     Returns:
         Explanation with summary and detail, or None on failure.
@@ -278,17 +290,19 @@ def explain_transaction(
     proxy_upgrade_info = _get_proxy_upgrade_info(calldata, target, chain_id)
     source_contexts = _collect_source_contexts([(target, decoded)], chain_id)
 
-    simulation = simulate_transaction(
-        target=target,
-        calldata=calldata,
-        chain_id=chain_id,
-        value=value,
-        from_address=from_address,
-    )
-    if simulation:
-        logger.info("Simulation completed: success=%s gas=%s", simulation.success, simulation.gas_used)
-    else:
-        logger.info("Simulation unavailable, proceeding with decoded calldata only")
+    simulation: SimulationResult | None = None
+    if not skip_simulation:
+        simulation = simulate_transaction(
+            target=target,
+            calldata=calldata,
+            chain_id=chain_id,
+            value=value,
+            from_address=from_address,
+        )
+        if simulation:
+            logger.info("Simulation completed: success=%s gas=%s", simulation.success, simulation.gas_used)
+        else:
+            logger.info("Simulation unavailable, proceeding with decoded calldata only")
 
     prompt = _build_prompt(
         target=target,
@@ -299,6 +313,7 @@ def explain_transaction(
         label=label,
         proxy_upgrade_info=proxy_upgrade_info,
         source_contexts=source_contexts,
+        context_note=context_note,
     )
     logger.info("Full AI context for %s:\n%s", target, prompt)
 
@@ -321,6 +336,8 @@ def explain_batch_transaction(
     protocol: str = "",
     label: str = "",
     from_address: str = "0x0000000000000000000000000000000000000000",
+    skip_simulation: bool = False,
+    context_note: str = "",
 ) -> Explanation | None:
     """Generate an AI explanation for a batch/multicall governance transaction.
 
@@ -330,6 +347,11 @@ def explain_batch_transaction(
         protocol: Protocol name for context.
         label: Human-readable label for the timelock/safe.
         from_address: Sender address for simulations.
+        skip_simulation: If True, do not call Tenderly. Useful for Safe multisend
+            batches where independent per-call simulation would break state-
+            dependent flows (approve+transferFrom, swapOwner+swapOwner, etc).
+        context_note: Optional preamble describing the execution context (e.g.
+            DELEGATECALL semantics) that the LLM can't infer from calldata alone.
 
     Returns:
         Explanation with summary and detail, or None on failure.
@@ -351,22 +373,21 @@ def explain_batch_transaction(
             decoded_calls.append(decoded)
             decoded_with_target.append((target, decoded))
 
-        sim = simulate_transaction(
-            target=target,
-            calldata=data,
-            chain_id=chain_id,
-            value=value,
-            from_address=from_address,
-        )
-        simulations.append(sim)
+        if not skip_simulation:
+            sim = simulate_transaction(
+                target=target,
+                calldata=data,
+                chain_id=chain_id,
+                value=value,
+                from_address=from_address,
+            )
+            simulations.append(sim)
 
     if not decoded_calls:
         return None
 
-    # Use the first successful simulation for context, or None
     simulation = next((s for s in simulations if s is not None), None)
 
-    # Detect proxy upgrades across all calls
     upgrade_parts: list[str] = []
     for call in calls:
         info = _get_proxy_upgrade_info(call.get("data", "0x"), call.get("target", ""), chain_id)
@@ -376,7 +397,6 @@ def explain_batch_transaction(
 
     source_contexts = _collect_source_contexts(decoded_with_target, chain_id)
 
-    # For batch, show all targets
     targets = ", ".join(c.get("target", "?") for c in calls)
     total_value = sum(int(c.get("value", "0")) for c in calls)
 
@@ -389,6 +409,7 @@ def explain_batch_transaction(
         label=label,
         proxy_upgrade_info=proxy_upgrade_info,
         source_contexts=source_contexts,
+        context_note=context_note,
     )
     logger.info("Full AI context for batch (%s calls):\n%s", len(calls), prompt)
 


### PR DESCRIPTION
## Summary

Safe transactions with \`operation=DELEGATECALL\` (typically multiSend batches via MultiSendCallOnly) currently produce misleading AI summaries claiming the tx won't execute on-chain — when in fact the on-chain tx is perfectly valid. Our plain-CALL Tenderly simulator can't model the delegated execution; inner calls would run with \`msg.sender = MultiSendCallOnly\` instead of the Safe, so authorization-gated functions like \`Safe.swapOwner\` revert in simulation.

This PR:

- Adds \`skip_simulation\` + \`context_note\` kwargs to \`explain_transaction\` / \`explain_batch_transaction\` — callers can opt out of Tenderly and feed the LLM an execution-context preamble.
- Adds \`safe/multisend.py\` with a Safe-utility address lookup (MultiSendCallOnly, MultiSend, SignMessageLib at canonical cross-chain addresses), an inner-call extractor that reads the Safe API's pre-decoded multiSend payload, and a context-note builder.
- Routes \`operation=1\` Safe txs through \`explain_batch_transaction\` with each inner call's source context fetched individually (Safe \`swapOwner\` natspec reaches the LLM via the proxy-follow path added in #218).

## Motivation

Production alert that triggered this work — Lido nonce 10:

> 🤖 AI Summary: This Lido governance transaction attempts to batch multiple contract calls via a \`MultiSendCallOnly\` contract, but the simulation reverts with zero gas used. The failure indicates either a malformed inner call or an attempt to use a \`delegatecall\` operation, which is forbidden by the target contract. The proposal will not execute on-chain in its current form.

After this PR, replayed live:

> 🤖 AI Summary: This transaction performs two sequential owner swaps on the LIDO Safe multisig, replacing two existing signers with new addresses. It is a standard governance key rotation with no asset movement or contract state changes beyond the owner list. Risk is LOW assuming the new owners are authorized.

## Why skip simulation rather than simulate inner calls individually

Considered re-simulating each inner call from the Safe address, but state-dependent flows (approve+transferFrom, swapOwner+swapOwner where the linked-list pointer changes between calls) would silently fail the second call. Skipping Tenderly and leaning on the LLM with proper context — decoded inner calls + per-target source context + execution-context note — gives better signal than a half-correct simulation.

A future PR could use Tenderly's bundle-simulate endpoint for stateful sequential sim if simulation results turn out to matter for governance txs.

## Test plan

- [x] \`uv run ruff check .\` passes
- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run pytest tests/\` — 144 pass (excluding pre-existing telegram failure on main)
- [x] Smoke-tested against live Lido nonce-10 tx: summary correctly classified as LOW-risk signer rotation
- [ ] Watch the first hourly Safe workflow run after merge for multisend txs

🤖 Generated with [Claude Code](https://claude.com/claude-code)