### PR TITLE
feat: optional self-critique refine pass for AI explainer

### DIFF
--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -10,6 +10,7 @@ from utils.llm.ai_explainer import (
     _format_decoded_calls,
     _format_simulation_context,
     _parse_explanation,
+    _refine_explanation,
     explain_transaction,
     format_explanation_line,
 )
@@ -494,6 +495,103 @@ class TestFormatExplanationLine(unittest.TestCase):
         self.assertIn("AI Summary", result)
         self.assertIn("This pauses the protocol.", result)
         self.assertNotIn("Full details", result)
+
+
+class TestRefineExplanation(unittest.TestCase):
+    """Tests for _refine_explanation."""
+
+    def test_pass_keeps_draft_unchanged(self) -> None:
+        draft = Explanation(summary="Lowers fee 30→25 bps. LOW.", detail="bla")
+        provider = MagicMock()
+        provider.complete.return_value = "PASS"
+        result = _refine_explanation("orig prompt", draft, provider)
+        self.assertIs(result, draft)
+        provider.complete.assert_called_once()
+
+    def test_pass_with_trailing_whitespace_still_keeps_draft(self) -> None:
+        draft = Explanation(summary="x", detail="y")
+        provider = MagicMock()
+        provider.complete.return_value = "  PASS  \n"
+        self.assertIs(_refine_explanation("p", draft, provider), draft)
+
+    def test_revision_replaces_draft(self) -> None:
+        draft = Explanation(summary="This transaction does X. LOW.", detail="bla")
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: Does X. LOW.\n\nDETAIL:\nrefined detail."
+        result = _refine_explanation("orig", draft, provider)
+        self.assertEqual(result.summary, "Does X. LOW.")
+        self.assertEqual(result.detail, "refined detail.")
+
+    def test_llm_error_falls_back_to_draft(self) -> None:
+        draft = Explanation(summary="x", detail="y")
+        provider = MagicMock()
+        provider.complete.side_effect = LLMError("rate limit")
+        self.assertIs(_refine_explanation("p", draft, provider), draft)
+
+    def test_empty_response_falls_back_to_draft(self) -> None:
+        draft = Explanation(summary="x", detail="y")
+        provider = MagicMock()
+        provider.complete.return_value = ""
+        self.assertIs(_refine_explanation("p", draft, provider), draft)
+
+    def test_revision_with_empty_summary_falls_back(self) -> None:
+        draft = Explanation(summary="x", detail="y")
+        provider = MagicMock()
+        # Reply parses to empty summary (no TLDR marker, no body)
+        provider.complete.return_value = ""
+        self.assertIs(_refine_explanation("p", draft, provider), draft)
+
+
+class TestRefineFlagInExplainTransaction(unittest.TestCase):
+    """Tests that the refine flag triggers a second LLM call."""
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer._collect_state_reads", return_value=[])
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    def test_refine_off_makes_one_call(
+        self,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_state: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(function_name="pause", signature="pause()")
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: Pauses. LOW."
+        provider.model_name = "test-model"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0xT", calldata="0x8456cb59", chain_id=1)
+        self.assertEqual(provider.complete.call_count, 1)
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer._collect_state_reads", return_value=[])
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    def test_refine_on_makes_two_calls(
+        self,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_state: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(function_name="pause", signature="pause()")
+        provider = MagicMock()
+        provider.complete.side_effect = ["TLDR: Pauses. LOW.", "PASS"]
+        provider.model_name = "test-model"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0xT", calldata="0x8456cb59", chain_id=1, refine=True)
+        self.assertEqual(provider.complete.call_count, 2)
+        # Second call should contain the critique task
+        second_call_prompt = provider.complete.call_args_list[1][0][0]
+        self.assertIn("Critique Task", second_call_prompt)
+        self.assertIn("Your Previous Draft", second_call_prompt)
 
 
 if __name__ == "__main__":

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -55,6 +55,41 @@ TLDR: <your short summary>
 DETAIL:
 <your detailed analysis>"""
 
+REFINE_TASK = """--- Critique Task ---
+Check the draft above against this checklist. Each item is a yes/no question:
+
+1. Does the TLDR start with a verb (NOT "This transaction" / "The proposal" /
+   "The transaction" / "This governance")?
+2. Is the TLDR ≤25 words?
+3. Does the TLDR end with a risk tag in CAPS (LOW / MEDIUM / HIGH / CRITICAL)?
+4. Are all numeric magnitudes/units in the draft supported by either the
+   Contract Source Context section or the Current State section above? Or
+   does the draft explicitly say the unit cannot be confirmed?
+5. If a Current State section showed before→after values, does the DETAIL
+   quote the concrete delta (e.g., "10× relaxation", "20% reduction")?
+6. Does the risk verdict match the magnitude of change shown in Current State?
+   (A 10× change to a critical parameter is rarely LOW; a no-op is rarely HIGH.)
+
+Hard rules for the revision (if you choose to revise):
+- Do NOT introduce a unit/scale assumption that wasn't in the draft. If the draft
+  says "raw values 1e15–8e15", do NOT rewrite as "<0.008 ETH". You don't know the
+  decimals unless the source context or state reads tell you.
+- Do NOT escalate a justifiable LOW out of caution.
+- Do NOT remove an explicit hedge ("unit cannot be confirmed", "without source
+  context", etc.).
+- Do NOT polish for style alone. Only edit if there's a concrete, specific issue
+  from items 1-6.
+
+If every check is satisfied AND no hard rule would be violated by the draft as-is,
+output exactly:
+PASS
+
+Otherwise output the revised explanation in the same format:
+TLDR: <revised>
+
+DETAIL:
+<revised>"""
+
 
 @dataclass(frozen=True)
 class Explanation:
@@ -314,6 +349,38 @@ def _parse_explanation(raw: str) -> Explanation:
     return Explanation(summary=raw.strip(), detail="")
 
 
+def _refine_explanation(original_prompt: str, draft: Explanation, provider) -> Explanation:
+    """Self-critique then revise. Returns the draft unchanged on PASS or any error."""
+    refine_prompt = (
+        f"{original_prompt}\n\n"
+        f"--- Your Previous Draft ---\n"
+        f"TLDR: {draft.summary}\n\n"
+        f"DETAIL:\n{draft.detail}\n\n"
+        f"{REFINE_TASK}"
+    )
+
+    try:
+        raw = provider.complete(refine_prompt)
+    except LLMError as e:
+        logger.warning("Refine pass failed (%s); keeping draft", e)
+        return draft
+
+    if not raw or not raw.strip():
+        return draft
+
+    if raw.strip().upper().startswith("PASS"):
+        logger.info("Refine pass: PASS (no changes)")
+        return draft
+
+    revised = _parse_explanation(raw)
+    if not revised.summary:
+        logger.warning("Refine pass returned empty summary; keeping draft")
+        return draft
+
+    logger.info("Refine pass produced a revision (TLDR %d→%d chars)", len(draft.summary), len(revised.summary))
+    return revised
+
+
 def explain_transaction(
     target: str,
     calldata: str,
@@ -324,6 +391,7 @@ def explain_transaction(
     from_address: str = "0x0000000000000000000000000000000000000000",
     skip_simulation: bool = False,
     context_note: str = "",
+    refine: bool = False,
 ) -> Explanation | None:
     """Generate an AI explanation for a governance transaction.
 
@@ -344,6 +412,8 @@ def explain_transaction(
         context_note: Optional preamble injected into the prompt to give the LLM
             context that isn't in the calldata (e.g. "this is delegated from
             a Safe; msg.sender of inner calls is the Safe itself").
+        refine: If True, runs a second LLM call that critiques the draft against
+            a checklist and revises only if it finds concrete issues. ~2× cost.
 
     Returns:
         Explanation with summary and detail, or None on failure.
@@ -393,6 +463,8 @@ def explain_transaction(
         provider = get_llm_provider()
         raw = provider.complete(prompt)
         explanation = _parse_explanation(raw)
+        if refine:
+            explanation = _refine_explanation(prompt, explanation, provider)
         logger.info("AI summary using %s:\n%s", provider.model_name, explanation.summary)
         if explanation.detail:
             logger.info("AI detail:\n%s", explanation.detail)
@@ -410,6 +482,7 @@ def explain_batch_transaction(
     from_address: str = "0x0000000000000000000000000000000000000000",
     skip_simulation: bool = False,
     context_note: str = "",
+    refine: bool = False,
 ) -> Explanation | None:
     """Generate an AI explanation for a batch/multicall governance transaction.
 
@@ -424,6 +497,8 @@ def explain_batch_transaction(
             dependent flows (approve+transferFrom, swapOwner+swapOwner, etc).
         context_note: Optional preamble describing the execution context (e.g.
             DELEGATECALL semantics) that the LLM can't infer from calldata alone.
+        refine: If True, runs a second LLM call that critiques the draft against
+            a checklist and revises only if it finds concrete issues. ~2× cost.
 
     Returns:
         Explanation with summary and detail, or None on failure.
@@ -491,6 +566,8 @@ def explain_batch_transaction(
         provider = get_llm_provider()
         raw = provider.complete(prompt)
         explanation = _parse_explanation(raw)
+        if refine:
+            explanation = _refine_explanation(prompt, explanation, provider)
         logger.info("Batch AI summary using %s:\n%s", provider.model_name, explanation.summary)
         if explanation.detail:
             logger.info("Batch AI detail:\n%s", explanation.detail)


### PR DESCRIPTION
## Summary

Adds a \`refine: bool = False\` flag to \`explain_transaction\` and \`explain_batch_transaction\`. When enabled, runs a second LLM call that critiques the draft against a 6-item checklist and revises only if it finds a concrete issue.

Returns the draft unchanged on PASS, on any \`LLMError\`, or if the revision parses to an empty summary.

## Critique prompt

Six checklist items: TLDR verb-leading, ≤25 words, trailing risk tag, supported units, before→after deltas when state was read, risk-magnitude consistency. Then hard rules that forbid:

- Introducing new unit/scale assumptions that weren't in the draft (main failure mode in early testing — refine pass invented "~0.008 ETH" units that weren't supported by source context).
- Removing explicit hedges.
- Escalating a justifiable LOW out of caution.
- Style-only polish.

## Smoke A/B (6 known txs)

| Tx | Without refine | With refine | Verdict |
|---|---|---|---|
| InfiniFi setMaxSlippage | LOW | LOW | neutral polish |
| 3JANE setConfig | MEDIUM | LOW | reasonable downgrade |
| CAP setCoverageCap batch | LOW (raw 1e15-8e15) | LOW (~0.0012 1e18 units) | refine now correctly hedges scale instead of asserting ETH |
| Lido swapOwner | LOW | LOW | neutral compression |
| 3JANE setCreditLines (2 borrowers) | LOW | MEDIUM | refine escalated; debatable |
| 3JANE setCreditLines (reverts) | LOW | MEDIUM | refine escalated a no-op; minor regression |

Refine adds occasional real value (catches over-cautious or under-cautious verdicts) but is roughly net-neutral on this small sample, with some run-to-run variance. Shipping behind the flag enables larger-scale A/B in production before flipping the default.

## Cost / latency

- ~2× LLM calls per alert when enabled. Negligible on \`deepseek-v4-flash\`.
- Latency doesn't matter for monitoring workflows.

## Test plan

- [x] \`uv run ruff check .\` passes
- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run pytest tests/\` — 180 pass (excluding pre-existing telegram failure on main)
- [x] Smoke A/B against 6 representative txs

🤖 Generated with [Claude Code](https://claude.com/claude-code)