### PR TITLE
ci: harden monitoring workflow inputs

### DIFF
--- a/.github/workflows/_run-monitoring.yml
+++ b/.github/workflows/_run-monitoring.yml
@@ -23,6 +23,9 @@ on:
         default: ""
         description: "Extra env vars as KEY=VALUE lines, written to $GITHUB_ENV before scripts run"
 
+permissions:
+  contents: read
+
 # ──────────────────────────────────────────────────────────────
 # Superset of all env vars used across workflows.
 # Adding an env var here for a secret that doesn't exist is harmless (empty string).
@@ -146,7 +149,17 @@ jobs:
 
       - name: Set extra environment variables
         if: inputs.extra_env != ''
-        run: echo "${{ inputs.extra_env }}" >> $GITHUB_ENV
+        env:
+          EXTRA_ENV: ${{ inputs.extra_env }}
+        run: |
+          while IFS= read -r line; do
+            [[ -z "$line" || "$line" == \#* ]] && continue
+            if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+              echo "Invalid environment assignment: $line" >&2
+              exit 1
+            fi
+            printf '%s\n' "$line" >> "$GITHUB_ENV"
+          done <<< "$EXTRA_ENV"
 
       - name: Restore cache
         if: inputs.cache_file != ''
@@ -161,24 +174,32 @@ jobs:
       - name: Get initial cache hash
         if: inputs.cache_file != ''
         id: initial-hash
-        run: echo "hash=${{ hashFiles(inputs.cache_file) }}" >> $GITHUB_OUTPUT
+        env:
+          CACHE_HASH: ${{ hashFiles(inputs.cache_file) }}
+        run: echo "hash=$CACHE_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Run monitoring scripts
+        env:
+          SCRIPTS: ${{ inputs.scripts }}
         run: |
           while IFS= read -r script; do
             script=$(echo "$script" | xargs)
             [[ -z "$script" || "$script" == \#* ]] && continue
+            if [[ ! "$script" =~ ^[A-Za-z0-9_./-]+$ ]]; then
+              echo "Invalid script path: $script" >&2
+              exit 1
+            fi
             echo "::group::Running: $script"
-            uv run $script
+            uv run "$script"
             echo "::endgroup::"
-          done <<'EOF'
-          ${{ inputs.scripts }}
-          EOF
+          done <<< "$SCRIPTS"
 
       - name: Get final cache hash
         if: inputs.cache_file != ''
         id: final-hash
-        run: echo "hash=${{ hashFiles(inputs.cache_file) }}" >> $GITHUB_OUTPUT
+        env:
+          CACHE_HASH: ${{ hashFiles(inputs.cache_file) }}
+        run: echo "hash=$CACHE_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Save cache
         if: always() && inputs.cache_file != '' && steps.initial-hash.outputs.hash != steps.final-hash.outputs.hash

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   daily:
     uses: ./.github/workflows/_run-monitoring.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       cache_file: cache-id-daily.txt

--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   hourly:
     uses: ./.github/workflows/_run-monitoring.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       cache_file: cache-id.txt
@@ -41,6 +43,8 @@ jobs:
 
   yearn-stuck-triggers:
     uses: ./.github/workflows/_run-monitoring.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       cache_file: tks-trigger-cache.json

--- a/.github/workflows/multisig-checker.yml
+++ b/.github/workflows/multisig-checker.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   multisig:
     uses: ./.github/workflows/_run-monitoring.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       cache_file: nonces.txt

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   weekly:
     uses: ./.github/workflows/_run-monitoring.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       extra_env: "GITHUB_RUN_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary
- validate extra_env lines before appending them to GITHUB_ENV
- validate and quote reusable workflow script paths before running them with uv
- avoid direct shell interpolation of reusable workflow inputs and cache hashes
- set read-only GitHub token permissions for monitoring workflows

## Validation
- ruby YAML parse over changed workflows
- uvx zizmor --offline --min-severity medium on changed workflows: targeted template-injection and excessive-permissions findings are cleared
- remaining zizmor findings are existing unpinned action refs and secrets: inherit warnings; the latter needs a follow-up per-script secret mapping rather than a cosmetic all-secrets mapping