### PR TITLE
fix(safe): skip dead-nonce pending txs in alerting

### DIFF
--- a/safe/main.py
+++ b/safe/main.py
@@ -92,11 +92,43 @@ def get_safe_transactions(
     return []
 
 
+def get_safe_current_nonce(safe_address: str, network_name: str) -> int | None:
+    """Fetch the safe's current onchain nonce (next nonce to use).
+
+    Uses the v1 Safe-info endpoint (v2 returns 404 for this resource). Returns
+    None if the call fails so callers can fall back gracefully.
+    """
+    base_url = safe_apis[network_name] + "/api/v1"
+    endpoint = f"{base_url}/safes/{safe_address}/"
+    api_key = next(_api_key_cycle)
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        response = requests.get(endpoint, headers=headers, timeout=10)
+        response.raise_for_status()
+        return int(response.json()["nonce"])
+    except (requests.RequestException, KeyError, ValueError) as e:
+        logger.warning("Failed to fetch current nonce for %s on %s: %s", safe_address, network_name, e)
+        return None
+
+
 def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]:
-    """Fetch pending transactions with nonce higher than the last cached nonce."""
+    """Fetch pending transactions worth alerting on.
+
+    Filters out two classes of noise:
+    - Already-cached: nonce <= last_cached_nonce (we've alerted on them).
+    - Dead-slot: nonce < safe.currentNonce. These remain in the API as
+      ``executed=false`` because a competing tx at the same nonce executed
+      first, but they will never run themselves.
+    """
     last_cached_nonce = get_last_executed_nonce_from_file(safe_address)
+    current_safe_nonce = get_safe_current_nonce(safe_address, network_name)
     pending_txs = get_safe_transactions(safe_address, network_name, executed=False)
-    return [tx for tx in pending_txs if int(tx["nonce"]) > last_cached_nonce]
+
+    baseline = last_cached_nonce
+    if current_safe_nonce is not None:
+        baseline = max(baseline, current_safe_nonce - 1)
+
+    return [tx for tx in pending_txs if int(tx["nonce"]) > baseline]
 
 
 def get_safe_url(safe_address: str, network_name: str) -> str:


### PR DESCRIPTION
## Summary
- The Safe transaction service returns every proposal that never executed — including competing proposals whose nonce slot was already consumed by a different executed tx. These stay ``executed=false`` forever and will never run.
- On a fresh cache (first run, GH Actions cache eviction, new safe added to ``ALL_SAFE_ADDRESSES``), each of those stale txs previously triggered an AI explanation + Telegram alert, flooding the channel with months-old history.
- The fix fetches the safe's current onchain nonce and filters pending where ``nonce > max(last_cached_nonce, current_nonce - 1)``. If the safe-info call fails we fall back to the existing cache-based filter so the monitor never breaks.

## Live verification
Tested against brain.ychad.eth (``0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7``) with an empty cache:

| | Pending nonces returned by API | After filter |
| - | - | - |
| Before | 3251, 3250, 3191, 3191, 3183, 3173, 3152, 3120, 3114, 3084 (10 alerts) | — |
| After | same 10 | 3251, 3250 (2 alerts) |

Current safe nonce is 3250, so only those two are live; the other 8 are stale rejections / replacements from Feb–Apr 2026.

## API note
The v2 endpoint ``/safes/{address}/`` returns 404 — only v1 exposes safe metadata. The multisig-transactions endpoint stays on v2.

## Test plan
- [ ] Merge after #234 (telegram markdown fix) so the YEARN_MS alert delivery is working
- [ ] Manually evict the ``nonces-v3`` GH Actions cache and confirm the next ``Monitor Safe Multisigs`` run posts at most 1-2 alerts per safe, not a backlog
- [ ] Confirm subsequent runs continue to alert on genuinely new pending txs

🤖 Generated with [Claude Code](https://claude.com/claude-code)