### PR TITLE
fix(safe): also accept proposedByDelegate when filtering pending txs

### DIFF
--- a/safe/main.py
+++ b/safe/main.py
@@ -203,12 +203,14 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
 
             if expected_proposers:
                 tx_proposer = (tx.get("proposer") or "").lower()
-                if tx_proposer in expected_proposers:
+                tx_delegate = (tx.get("proposedByDelegate") or "").lower()
+                matched = next((a for a in (tx_proposer, tx_delegate) if a and a in expected_proposers), None)
+                if matched:
                     logger.info(
                         "Skipping nonce %s on %s — proposed by expected address %s",
                         nonce,
                         safe_address,
-                        tx_proposer,
+                        matched,
                     )
                     write_last_executed_nonce_to_file(safe_address, nonce)
                     continue

--- a/safe/main.py
+++ b/safe/main.py
@@ -189,7 +189,7 @@ def _explain_safe_tx(
 
 def check_for_pending_transactions(safe_address: str, network_name: str, protocol: str) -> None:
     pending_transactions = get_pending_transactions(safe_address, network_name)
-    expected_proposers = YEARN_EXPECTED_PROPOSERS.get((network_name, safe_address.lower()))
+    expected_proposers = {a.lower() for a in YEARN_EXPECTED_PROPOSERS.get((network_name, safe_address.lower()), ())}
 
     if pending_transactions:
         for tx in pending_transactions:


### PR DESCRIPTION
## Summary

The proposer-based noise filter only checked `tx[\"proposer\"]`. When a delegate proposes on behalf of a human signer, the human address ends up in `proposer` and only `proposedByDelegate` is stable across humans — so every new signer alerts once, even when the delegate is already on the trusted list. Concrete example: Strategist Multisig mainnet nonce 3250 alerted because `proposer = 0xFafFb75e…` (a human) while the bot was `proposedByDelegate = 0xcE434267…`.

Filter now matches on either `proposer` or `proposedByDelegate`. The Strategist delegate is already in `YEARN_EXPECTED_PROPOSERS` on main (added via the same refactor that swapped bots), so once this lands, nonce 3250 and similar pending txs get auto-skipped.

Markdown-escape fixes from the original commit on this branch are now redundant with #234 and have been dropped on rebase.

## Test plan

- [ ] Lint + format pass (`uv run ruff check .` / `uv run ruff format --check .`).
- [ ] Next scheduled `Monitor Safe Multisigs` run shows `INFO safe: Skipping nonce 3250 on 0x16388463… — proposed by expected address 0xce434267…` instead of firing an alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)