### PR TITLE
feat(ai-explainer): deeper LLM context — ABI names, persistent cache, parallel lookups, address resolver, ERC20 metadata, risk anchors

### DIFF
--- a/.github/workflows/_run-monitoring.yml
+++ b/.github/workflows/_run-monitoring.yml
@@ -172,11 +172,31 @@ jobs:
           restore-keys: |
             ${{ inputs.cache_key_prefix }}-
 
+      # Shared 4byte selector cache. Lives outside the per-workflow `cache_file`
+      # because every workflow's Sourcify hits are equally valid to every other
+      # workflow's: selectors are deterministic, chain-agnostic, and identical
+      # across all callers. One shared key means the hourly run warms up the
+      # cache for the multisig-checker, the timelock alerts, etc.
+      - name: Restore selector cache
+        id: selector-cache-restore
+        uses: actions/cache/restore@v5
+        with:
+          path: selector-cache.txt
+          key: selector-cache-v1-${{ hashFiles('selector-cache.txt') }}
+          restore-keys: |
+            selector-cache-v1-
+
       - name: Get initial cache hash
         if: inputs.cache_file != ''
         id: initial-hash
         env:
           CACHE_HASH: ${{ hashFiles(inputs.cache_file) }}
+        run: echo "hash=$CACHE_HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Get initial selector-cache hash
+        id: initial-selector-hash
+        env:
+          CACHE_HASH: ${{ hashFiles('selector-cache.txt') }}
         run: echo "hash=$CACHE_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Run monitoring scripts
@@ -202,9 +222,25 @@ jobs:
           CACHE_HASH: ${{ hashFiles(inputs.cache_file) }}
         run: echo "hash=$CACHE_HASH" >> "$GITHUB_OUTPUT"
 
+      - name: Get final selector-cache hash
+        id: final-selector-hash
+        env:
+          CACHE_HASH: ${{ hashFiles('selector-cache.txt') }}
+        run: echo "hash=$CACHE_HASH" >> "$GITHUB_OUTPUT"
+
       - name: Save cache
         if: always() && inputs.cache_file != '' && steps.initial-hash.outputs.hash != steps.final-hash.outputs.hash
         uses: actions/cache/save@v5
         with:
           path: ${{ inputs.cache_file }}
           key: ${{ inputs.cache_key_prefix }}-${{ hashFiles(inputs.cache_file) }}
+
+      # Only save when the file actually grew/changed and isn't empty. Concurrent
+      # workflows racing on save are handled by actions/cache@v5 — first writer
+      # with a given key wins, others no-op silently.
+      - name: Save selector cache
+        if: always() && steps.initial-selector-hash.outputs.hash != steps.final-selector-hash.outputs.hash && steps.final-selector-hash.outputs.hash != ''
+        uses: actions/cache/save@v5
+        with:
+          path: selector-cache.txt
+          key: selector-cache-v1-${{ hashFiles('selector-cache.txt') }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ htmlcov/
 # Cache files
 cache-id.txt
 tks-trigger-cache.json
+selector-cache.txt
 *.cache
 .uv/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest fixtures shared across the test suite."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_live_etherscan_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default ETHERSCAN_TOKEN to empty so tests don't accidentally hit the live API.
+
+    Several tests in test_ai_explainer.py exercise paths that internally call
+    Etherscan (via fetch_source / fetch_function_input_names). When a developer
+    has ETHERSCAN_TOKEN set in their environment, those tests would make real
+    network requests and assertions would depend on live API state. Tests that
+    actually want to exercise the Etherscan path override this via
+    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"}).
+    """
+    if os.environ.get("ETHERSCAN_TOKEN"):
+        monkeypatch.delenv("ETHERSCAN_TOKEN", raising=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,12 @@
-"""Pytest fixtures shared across the test suite."""
+"""Pytest fixtures shared across the test suite.
+
+Tests are supposed to mock their own network dependencies. None of our tests
+make real RPC calls or hit Etherscan — every place that touches ChainManager
+or `fetch_source` patches the call site. The fixtures here are defense-in-
+depth: they make sure that if a future test forgets a mock, the failure is a
+clean "no token" / "no provider" rather than a slow live call that depends
+on which env vars the developer happens to have set.
+"""
 
 import os
 
@@ -6,23 +14,20 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _no_live_network_calls(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Block accidental live API calls during tests.
+def _isolate_from_live_apis(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Block accidental live API/RPC calls and reset cross-test singletons.
 
-    Strips Etherscan + RPC provider env vars so any test that forgets to mock
-    a network-touching helper fails fast (with a clear "no provider" error)
-    rather than hitting the real Internet and making the test slow / flaky /
-    dependent on live state. Tests that actually want to exercise these
-    paths override via @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "...",
-    "PROVIDER_URL_MAINNET": "..."}).
+    Strips `ETHERSCAN_TOKEN` and every `PROVIDER_URL_*` so a missing mock
+    short-circuits cheaply via the "no token / no provider" code paths that
+    already exist for production use. Tests that intentionally exercise
+    those code paths opt back in via @patch.dict.
+
+    Also clears `ChainManager._instances` so a real client object cached by
+    one test can't leak into the next.
     """
     for key in list(os.environ):
         if key == "ETHERSCAN_TOKEN" or key.startswith("PROVIDER_URL_"):
             monkeypatch.delenv(key, raising=False)
-
-    # ChainManager memoizes Web3Client instances. A previous test that ran
-    # with a real provider URL could have cached one — stale singletons
-    # would then make live calls even after we strip env vars above.
     try:
         from utils.web3_wrapper import ChainManager
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,26 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _no_live_etherscan_calls(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default ETHERSCAN_TOKEN to empty so tests don't accidentally hit the live API.
+def _no_live_network_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Block accidental live API calls during tests.
 
-    Several tests in test_ai_explainer.py exercise paths that internally call
-    Etherscan (via fetch_source / fetch_function_input_names). When a developer
-    has ETHERSCAN_TOKEN set in their environment, those tests would make real
-    network requests and assertions would depend on live API state. Tests that
-    actually want to exercise the Etherscan path override this via
-    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"}).
+    Strips Etherscan + RPC provider env vars so any test that forgets to mock
+    a network-touching helper fails fast (with a clear "no provider" error)
+    rather than hitting the real Internet and making the test slow / flaky /
+    dependent on live state. Tests that actually want to exercise these
+    paths override via @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "...",
+    "PROVIDER_URL_MAINNET": "..."}).
     """
-    if os.environ.get("ETHERSCAN_TOKEN"):
-        monkeypatch.delenv("ETHERSCAN_TOKEN", raising=False)
+    for key in list(os.environ):
+        if key == "ETHERSCAN_TOKEN" or key.startswith("PROVIDER_URL_"):
+            monkeypatch.delenv(key, raising=False)
+
+    # ChainManager memoizes Web3Client instances. A previous test that ran
+    # with a real provider URL could have cached one — stale singletons
+    # would then make live calls even after we strip env vars above.
+    try:
+        from utils.web3_wrapper import ChainManager
+
+        ChainManager._instances.clear()
+    except Exception:  # noqa: BLE001 - test setup is best-effort
+        pass

--- a/tests/test_address_resolver.py
+++ b/tests/test_address_resolver.py
@@ -1,0 +1,80 @@
+"""Tests for utils/address_resolver.py."""
+
+import unittest
+from unittest.mock import patch
+
+from utils.address_resolver import register_backend, resolve_address_label
+
+
+class TestResolveAddressLabel(unittest.TestCase):
+    """Backend chain: tries each in order, returns first non-empty result."""
+
+    def test_first_backend_wins(self) -> None:
+        # Safe utility shortcut hits before anything else.
+        label = resolve_address_label(1, "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D")
+        self.assertEqual(label, "Safe MultiSendCallOnly")
+
+    @patch("utils.address_resolver._etherscan_backend", return_value="EtherscanName")
+    @patch("utils.address_resolver._swiss_knife_backend", return_value="SwissName")
+    def test_swiss_knife_wins_over_etherscan(self, mock_sk: object, mock_es: object) -> None:
+        # Random address that doesn't hit the Safe registry.
+        label = resolve_address_label(1, "0x" + "ab" * 20)
+        self.assertEqual(label, "SwissName")
+        mock_es.assert_not_called()  # type: ignore[attr-defined]
+
+    @patch("utils.address_resolver._etherscan_backend", return_value="EtherscanName")
+    @patch("utils.address_resolver._swiss_knife_backend", return_value="")
+    def test_falls_through_to_etherscan(self, mock_sk: object, mock_es: object) -> None:
+        label = resolve_address_label(1, "0x" + "ab" * 20)
+        self.assertEqual(label, "EtherscanName")
+
+    @patch("utils.address_resolver._etherscan_backend", return_value="")
+    @patch("utils.address_resolver._swiss_knife_backend", return_value="")
+    def test_all_miss_returns_empty(self, mock_sk: object, mock_es: object) -> None:
+        self.assertEqual(resolve_address_label(1, "0x" + "ab" * 20), "")
+
+    def test_empty_address(self) -> None:
+        self.assertEqual(resolve_address_label(1, ""), "")
+
+    @patch("utils.address_resolver._etherscan_backend", return_value="EtherscanName")
+    @patch("utils.address_resolver._swiss_knife_backend", side_effect=RuntimeError("API down"))
+    def test_failed_backend_skipped(self, mock_sk: object, mock_es: object) -> None:
+        # Swiss Knife raising shouldn't kill the chain — Etherscan still tried.
+        label = resolve_address_label(1, "0x" + "ab" * 20)
+        self.assertEqual(label, "EtherscanName")
+
+
+class TestRegisterBackend(unittest.TestCase):
+    def test_appends_to_end(self) -> None:
+        import utils.address_resolver as resolver
+
+        def my_appended_backend(chain_id: int, address: str) -> str:
+            return ""
+
+        original_names = list(resolver._BACKEND_NAMES)
+        try:
+            register_backend(my_appended_backend)
+            self.assertEqual(resolver._BACKEND_NAMES[-1], "my_appended_backend")
+        finally:
+            resolver._BACKEND_NAMES[:] = original_names
+            resolver.__dict__.pop("my_appended_backend", None)
+
+    def test_inserts_at_position(self) -> None:
+        import utils.address_resolver as resolver
+
+        def my_priority_backend(chain_id: int, address: str) -> str:
+            return "WINS"
+
+        original_names = list(resolver._BACKEND_NAMES)
+        try:
+            register_backend(my_priority_backend, position=0)
+            self.assertEqual(resolver._BACKEND_NAMES[0], "my_priority_backend")
+            # Now it wins even for known Safe utility addresses.
+            self.assertEqual(resolve_address_label(1, "0x40A2aCCbd92BCA938b02010E17A5b8929b49130D"), "WINS")
+        finally:
+            resolver._BACKEND_NAMES[:] = original_names
+            resolver.__dict__.pop("my_priority_backend", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -600,6 +600,146 @@ class TestAbiParamNames(unittest.TestCase):
         self.assertIn("uint256: 1", decoded_section)
 
 
+class TestErc20MetadataInPrompt(unittest.TestCase):
+    """ERC20 symbol/decimals are appended to address labels so the LLM can size amounts."""
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata")
+    @patch("utils.llm.ai_explainer.get_contract_label")
+    def test_erc20_target_gets_decimals_suffix(
+        self,
+        mock_label: MagicMock,
+        mock_meta: MagicMock,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        from utils.erc20_metadata import ERC20Metadata
+
+        usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        mock_decode.return_value = DecodedCall(
+            function_name="transfer",
+            signature="transfer(address,uint256)",
+            params=[("address", "0x" + "11" * 20), ("uint256", 1000000)],
+        )
+
+        # Label resolver returns the USDC name; metadata fills in decimals.
+        def label_for(_chain: int, addr: str) -> str:
+            return "Circle: USDC Token" if addr.lower() == usdc.lower() else ""
+
+        mock_label.side_effect = label_for
+        mock_meta.side_effect = lambda _c, addr: ERC20Metadata("USDC", 6) if addr.lower() == usdc.lower() else None
+
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: tiny transfer. LOW."
+        provider.model_name = "test"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target=usdc, calldata="0xa9059cbb" + "00" * 64, chain_id=1)
+        prompt = provider.complete.call_args[0][0]
+        # Target line should show the token symbol + decimals.
+        self.assertIn("Circle: USDC Token (USDC, 6 dec)", prompt)
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
+    @patch("utils.llm.ai_explainer.get_contract_label", return_value="FarmRegistry")
+    def test_non_erc20_keeps_label_unchanged(
+        self,
+        mock_label: MagicMock,
+        mock_meta: MagicMock,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(
+            function_name="addFarms",
+            signature="addFarms(uint256,address[])",
+            params=[("uint256", 1), ("address[]", ("0x" + "ac" * 20,))],
+        )
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: registers farm. LOW."
+        provider.model_name = "test"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0x" + "ff" * 20, calldata="0xabcdef10" + "00" * 64, chain_id=1)
+        prompt = provider.complete.call_args[0][0]
+        # FarmRegistry label without ERC20 decoration.
+        self.assertIn("FarmRegistry", prompt)
+        self.assertNotIn("dec)", prompt)
+
+
+class TestRiskAnchorsSection(unittest.TestCase):
+    """Risk Anchors block is added for calls with anchored selectors."""
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
+    @patch("utils.llm.ai_explainer.get_contract_label", return_value="")
+    def test_anchor_section_added_for_known_selector(
+        self,
+        mock_label: MagicMock,
+        mock_meta: MagicMock,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(
+            function_name="transferOwnership",
+            signature="transferOwnership(address)",
+            params=[("address", "0x" + "11" * 20)],
+        )
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: hands ownership. HIGH."
+        provider.model_name = "test"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0x" + "ff" * 20, calldata="0xf2fde38b" + "00" * 32, chain_id=1)
+        prompt = provider.complete.call_args[0][0]
+        self.assertIn("--- Risk Anchors ---", prompt)
+        self.assertIn("transferOwnership(address) → typically HIGH", prompt)
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
+    @patch("utils.llm.ai_explainer.get_contract_label", return_value="")
+    def test_no_anchor_section_for_unknown_selector(
+        self,
+        mock_label: MagicMock,
+        mock_meta: MagicMock,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        # setMaxSlippage isn't anchored — parameter-dependent.
+        mock_decode.return_value = DecodedCall(
+            function_name="setMaxSlippage",
+            signature="setMaxSlippage(uint256)",
+            params=[("uint256", 1)],
+        )
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: tightens slippage. LOW."
+        provider.model_name = "test"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0x" + "ff" * 20, calldata="0x736defe0" + "00" * 32, chain_id=1)
+        prompt = provider.complete.call_args[0][0]
+        self.assertNotIn("--- Risk Anchors ---", prompt)
+
+
 class TestNestedBytesDecoding(unittest.TestCase):
     """`bytes` arguments that hold inner calldata are recursively decoded."""
 
@@ -635,8 +775,12 @@ class TestNestedBytesDecoding(unittest.TestCase):
 
     def test_unknown_selector_skipped_no_network(self) -> None:
         """A bytes blob whose selector isn't in KNOWN_SELECTORS must not trigger a network lookup."""
+        from utils.calldata.decoder import _selector_cache
         from utils.llm.ai_explainer import _format_decoded_calls
 
+        # Pollution from the persistent cache (prior runs may have resolved
+        # this selector to something) would defeat the offline-only guard.
+        _selector_cache.pop("0xdeadbeef", None)
         unknown = "0xdeadbeef" + "00" * 32  # well-formed length, selector unknown
         outer = DecodedCall(
             function_name="exec",
@@ -753,7 +897,7 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
-    def test_target_address_is_not_relabeled(
+    def test_target_appearing_as_arg_is_deduped(
         self,
         mock_label: MagicMock,
         mock_decode: MagicMock,
@@ -761,13 +905,15 @@ class TestAddressLabels(unittest.TestCase):
         mock_get_provider: MagicMock,
         mock_source: MagicMock,
     ) -> None:
-        # The target appears as its own argument — should be skipped so we don't
-        # double up with the Contract Source Context block.
+        # The target now also gets labeled (so the Target: line can show
+        # ERC20 decimals/symbol). When the same address appears as an
+        # argument, we still want exactly one resolver call, not two.
         mock_decode.return_value = DecodedCall(
             function_name="selfWire",
             signature="selfWire(address)",
             params=[("address", self.REGISTRY.lower())],
         )
+        mock_label.return_value = ""
         provider = MagicMock()
         provider.complete.return_value = "TLDR: wires self. LOW."
         provider.model_name = "test-model"
@@ -775,7 +921,7 @@ class TestAddressLabels(unittest.TestCase):
 
         explain_transaction(target=self.REGISTRY, calldata="0xdeadbeef" + "00" * 32, chain_id=1)
 
-        mock_label.assert_not_called()
+        self.assertEqual(mock_label.call_count, 1)
 
     @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
     @patch("utils.llm.ai_explainer.get_llm_provider")
@@ -864,19 +1010,24 @@ class TestAddressLabels(unittest.TestCase):
         mock_get_provider: MagicMock,
         mock_source: MagicMock,
     ) -> None:
+        # The target is still resolved (it's a real address) but the zero
+        # address arg must be filtered before reaching the label resolver.
         zero = "0x" + "00" * 20
         mock_decode.return_value = DecodedCall(
             function_name="setOracle",
             signature="setOracle(address)",
             params=[("address", zero)],
         )
+        mock_label.return_value = ""
         provider = MagicMock()
         provider.complete.return_value = "TLDR: unsets oracle. LOW."
         provider.model_name = "test-model"
         mock_get_provider.return_value = provider
 
         explain_transaction(target=self.REGISTRY, calldata="0x7adbf973" + "00" * 32, chain_id=1)
-        mock_label.assert_not_called()
+        # Resolver called exactly once — for the target, not for the zero arg.
+        addresses_queried = {call.args[1].lower() for call in mock_label.call_args_list}
+        self.assertNotIn(zero, addresses_queried)
 
 
 if __name__ == "__main__":

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -539,6 +539,67 @@ class TestFailedSimulationDropped(unittest.TestCase):
         self.assertNotIn("FAILED", prompt)
 
 
+class TestAbiParamNames(unittest.TestCase):
+    """When the ABI is available, parameters render as `type name: value`."""
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    @patch("utils.llm.ai_explainer.fetch_function_input_names")
+    def test_named_params_appear_in_prompt(
+        self,
+        mock_names: MagicMock,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(
+            function_name="setMaxSlippage",
+            signature="setMaxSlippage(uint256)",
+            params=[("uint256", 950000000000000000)],
+        )
+        mock_names.return_value = ["_maxSlippage"]
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: tightens slippage. LOW."
+        provider.model_name = "test"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0xT", calldata="0x736defe0" + "00" * 32, chain_id=1)
+        prompt = provider.complete.call_args[0][0]
+        self.assertIn("uint256 _maxSlippage: 950000000000000000", prompt)
+
+    @patch("utils.llm.ai_explainer.get_source_context", return_value=None)
+    @patch("utils.llm.ai_explainer.get_llm_provider")
+    @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
+    @patch("utils.llm.ai_explainer.decode_calldata")
+    @patch("utils.llm.ai_explainer.fetch_function_input_names", return_value=None)
+    def test_falls_back_to_bare_types_when_abi_missing(
+        self,
+        mock_names: MagicMock,
+        mock_decode: MagicMock,
+        mock_simulate: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_source: MagicMock,
+    ) -> None:
+        mock_decode.return_value = DecodedCall(
+            function_name="setMaxSlippage",
+            signature="setMaxSlippage(uint256)",
+            params=[("uint256", 1)],
+        )
+        provider = MagicMock()
+        provider.complete.return_value = "TLDR: tightens slippage. LOW."
+        provider.model_name = "test"
+        mock_get_provider.return_value = provider
+
+        explain_transaction(target="0xT", calldata="0x736defe0" + "00" * 32, chain_id=1)
+        prompt = provider.complete.call_args[0][0]
+        # Without ABI names, params render as plain `type: value`.
+        decoded_section = prompt.split("--- Decoded Calldata ---")[1]
+        self.assertIn("uint256: 1", decoded_section)
+
+
 class TestNestedBytesDecoding(unittest.TestCase):
     """`bytes` arguments that hold inner calldata are recursively decoded."""
 

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -835,8 +835,10 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
     def test_address_array_arg_is_labeled(
         self,
+        mock_meta: MagicMock,
         mock_label: MagicMock,
         mock_decode: MagicMock,
         mock_simulate: MagicMock,
@@ -868,8 +870,10 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
     def test_scalar_address_arg_is_labeled(
         self,
+        mock_meta: MagicMock,
         mock_label: MagicMock,
         mock_decode: MagicMock,
         mock_simulate: MagicMock,
@@ -897,8 +901,10 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
     def test_target_appearing_as_arg_is_deduped(
         self,
+        mock_meta: MagicMock,
         mock_label: MagicMock,
         mock_decode: MagicMock,
         mock_simulate: MagicMock,
@@ -928,8 +934,10 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
     def test_unverified_address_left_unannotated(
         self,
+        mock_meta: MagicMock,
         mock_label: MagicMock,
         mock_decode: MagicMock,
         mock_simulate: MagicMock,
@@ -959,8 +967,10 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
     def test_address_inside_nested_bytes_is_labeled(
         self,
+        mock_meta: MagicMock,
         mock_label: MagicMock,
         mock_decode: MagicMock,
         mock_simulate: MagicMock,
@@ -1002,8 +1012,10 @@ class TestAddressLabels(unittest.TestCase):
     @patch("utils.llm.ai_explainer.simulate_transaction", return_value=None)
     @patch("utils.llm.ai_explainer.decode_calldata")
     @patch("utils.llm.ai_explainer.get_contract_label")
+    @patch("utils.llm.ai_explainer.fetch_erc20_metadata", return_value=None)
     def test_zero_address_not_queried(
         self,
+        mock_meta: MagicMock,
         mock_label: MagicMock,
         mock_decode: MagicMock,
         mock_simulate: MagicMock,

--- a/tests/test_calldata_decoder.py
+++ b/tests/test_calldata_decoder.py
@@ -270,5 +270,65 @@ class TestFormatCallLines(unittest.TestCase):
         self.assertEqual(lines[0], "📝 Function: `pause()`")
 
 
+class TestPersistentSelectorCache(unittest.TestCase):
+    """Selector cache is persisted to disk so Sourcify is queried at most once per run."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        # Point the cache at a fresh temp file for this test.
+        self._tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+        self._tmp.close()
+        self._patcher = patch("utils.calldata.decoder._SELECTOR_CACHE_FILE", self._tmp.name)
+        self._patcher.start()
+        _selector_cache.clear()
+
+    def tearDown(self) -> None:
+        import os
+
+        self._patcher.stop()
+        try:
+            os.unlink(self._tmp.name)
+        except OSError:
+            pass
+
+    @patch("utils.calldata.decoder.fetch_json")
+    def test_sourcify_hit_is_persisted(self, mock_fetch: object) -> None:
+        from utils.calldata.decoder import _load_selector_cache
+
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "result": {"function": {_UNKNOWN_SELECTOR: [{"name": "doSomething(uint256)"}]}}
+        }
+        sig = resolve_selector(_UNKNOWN_SELECTOR)
+        self.assertEqual(sig, "doSomething(uint256)")
+        # The on-disk cache should now contain it.
+        reloaded = _load_selector_cache()
+        self.assertEqual(reloaded.get(_UNKNOWN_SELECTOR), "doSomething(uint256)")
+
+    @patch("utils.calldata.decoder.fetch_json")
+    def test_sourcify_miss_is_persisted(self, mock_fetch: object) -> None:
+        from utils.calldata.decoder import _load_selector_cache
+
+        # No data → negative cache.
+        mock_fetch.return_value = None  # type: ignore[attr-defined]
+        self.assertIsNone(resolve_selector(_UNKNOWN_SELECTOR))
+        reloaded = _load_selector_cache()
+        self.assertIn(_UNKNOWN_SELECTOR, reloaded)
+        self.assertIsNone(reloaded[_UNKNOWN_SELECTOR])
+
+    @patch("utils.calldata.decoder.fetch_json")
+    def test_persisted_negative_avoids_retry(self, mock_fetch: object) -> None:
+        # Pre-populate disk cache with a negative result, then ensure
+        # the in-memory cache picks it up and skips the network call.
+        with open(self._tmp.name, "w") as f:
+            f.write(f"{_UNKNOWN_SELECTOR}|__NONE__\n")
+        from utils.calldata.decoder import _load_selector_cache
+
+        cache = _load_selector_cache()
+        _selector_cache.update(cache)
+        self.assertIsNone(resolve_selector(_UNKNOWN_SELECTOR))
+        mock_fetch.assert_not_called()  # type: ignore[attr-defined]
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_calldata_decoder.py
+++ b/tests/test_calldata_decoder.py
@@ -306,15 +306,57 @@ class TestPersistentSelectorCache(unittest.TestCase):
         self.assertEqual(reloaded.get(_UNKNOWN_SELECTOR), "doSomething(uint256)")
 
     @patch("utils.calldata.decoder.fetch_json")
-    def test_sourcify_miss_is_persisted(self, mock_fetch: object) -> None:
+    def test_transient_failure_not_persisted(self, mock_fetch: object) -> None:
+        # `fetch_json` returns None on HTTP error / timeout / network failure.
+        # We must NOT persist a __NONE__ entry — that would permanently
+        # blacklist the selector across the shared CI cache after a single
+        # bad request.
         from utils.calldata.decoder import _load_selector_cache
 
-        # No data → negative cache.
         mock_fetch.return_value = None  # type: ignore[attr-defined]
+        self.assertIsNone(resolve_selector(_UNKNOWN_SELECTOR))
+        reloaded = _load_selector_cache()
+        self.assertNotIn(_UNKNOWN_SELECTOR, reloaded)
+        # But the in-memory cache should remember the miss for this run.
+        self.assertIn(_UNKNOWN_SELECTOR, _selector_cache)
+        self.assertIsNone(_selector_cache[_UNKNOWN_SELECTOR])
+
+    @patch("utils.calldata.decoder.fetch_json")
+    def test_malformed_response_not_persisted(self, mock_fetch: object) -> None:
+        # Response doesn't match the {"result": {"function": {...}}} shape —
+        # treat as transient, same as a network error.
+        from utils.calldata.decoder import _load_selector_cache
+
+        mock_fetch.return_value = {"unexpected": "shape"}  # type: ignore[attr-defined]
+        self.assertIsNone(resolve_selector(_UNKNOWN_SELECTOR))
+        self.assertNotIn(_UNKNOWN_SELECTOR, _load_selector_cache())
+
+    @patch("utils.calldata.decoder.fetch_json")
+    def test_explicit_miss_is_persisted(self, mock_fetch: object) -> None:
+        # Well-formed response with an empty result list for this selector —
+        # Sourcify is explicitly saying "we don't know this one". Safe to
+        # persist so future runs skip the lookup.
+        from utils.calldata.decoder import _load_selector_cache
+
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "result": {"function": {_UNKNOWN_SELECTOR: []}}
+        }
         self.assertIsNone(resolve_selector(_UNKNOWN_SELECTOR))
         reloaded = _load_selector_cache()
         self.assertIn(_UNKNOWN_SELECTOR, reloaded)
         self.assertIsNone(reloaded[_UNKNOWN_SELECTOR])
+
+    @patch("utils.calldata.decoder.fetch_json")
+    def test_well_formed_response_with_no_key_persists(self, mock_fetch: object) -> None:
+        # Schema looks right but the selector isn't even in the response
+        # dict. Same semantics as an empty list — definitive miss.
+        from utils.calldata.decoder import _load_selector_cache
+
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "result": {"function": {}}
+        }
+        self.assertIsNone(resolve_selector(_UNKNOWN_SELECTOR))
+        self.assertIn(_UNKNOWN_SELECTOR, _load_selector_cache())
 
     @patch("utils.calldata.decoder.fetch_json")
     def test_persisted_negative_avoids_retry(self, mock_fetch: object) -> None:

--- a/tests/test_erc20_metadata.py
+++ b/tests/test_erc20_metadata.py
@@ -1,0 +1,67 @@
+"""Tests for utils/erc20_metadata.py."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from utils.erc20_metadata import ERC20Metadata, fetch_erc20_metadata, reset_cache
+
+
+class TestFetchErc20Metadata(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_cache()
+
+    @patch("utils.erc20_metadata.ChainManager")
+    def test_returns_symbol_and_decimals(self, mock_cm: MagicMock) -> None:
+        client = MagicMock()
+        client.execute_batch.return_value = ("USDC", 6)
+        client.batch_requests.return_value.__enter__.return_value = MagicMock()
+        client.batch_requests.return_value.__exit__.return_value = False
+        mock_cm.get_client.return_value = client
+
+        meta = fetch_erc20_metadata(1, "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+        self.assertEqual(meta, ERC20Metadata(symbol="USDC", decimals=6))
+
+    @patch("utils.erc20_metadata.ChainManager")
+    def test_returns_none_on_eth_call_failure(self, mock_cm: MagicMock) -> None:
+        client = MagicMock()
+        client.batch_requests.side_effect = RuntimeError("execution reverted")
+        mock_cm.get_client.return_value = client
+
+        meta = fetch_erc20_metadata(1, "0x" + "ab" * 20)
+        self.assertIsNone(meta)
+
+    def test_invalid_address_skips_network(self) -> None:
+        with patch("utils.erc20_metadata.ChainManager") as mock_cm:
+            self.assertIsNone(fetch_erc20_metadata(1, ""))
+            self.assertIsNone(fetch_erc20_metadata(1, "0xshort"))
+            self.assertIsNone(fetch_erc20_metadata(1, "not-hex"))
+            mock_cm.get_client.assert_not_called()
+
+    @patch("utils.erc20_metadata.ChainManager")
+    def test_caches_repeat_lookups(self, mock_cm: MagicMock) -> None:
+        client = MagicMock()
+        client.execute_batch.return_value = ("USDC", 6)
+        client.batch_requests.return_value.__enter__.return_value = MagicMock()
+        client.batch_requests.return_value.__exit__.return_value = False
+        mock_cm.get_client.return_value = client
+
+        addr = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        fetch_erc20_metadata(1, addr)
+        fetch_erc20_metadata(1, addr)
+        self.assertEqual(client.batch_requests.call_count, 1)
+
+    @patch("utils.erc20_metadata.ChainManager")
+    def test_caches_misses(self, mock_cm: MagicMock) -> None:
+        client = MagicMock()
+        client.batch_requests.side_effect = RuntimeError("not a token")
+        mock_cm.get_client.return_value = client
+
+        addr = "0x" + "cd" * 20
+        self.assertIsNone(fetch_erc20_metadata(1, addr))
+        self.assertIsNone(fetch_erc20_metadata(1, addr))
+        # Cached miss → only one attempt.
+        self.assertEqual(client.batch_requests.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_risk_anchors.py
+++ b/tests/test_risk_anchors.py
@@ -1,0 +1,53 @@
+"""Tests for utils/risk_anchors.py."""
+
+import unittest
+
+from utils.risk_anchors import RiskAnchor, format_anchors_block, lookup
+
+
+class TestLookup(unittest.TestCase):
+    def test_known_high_risk_selector(self) -> None:
+        anchor = lookup("0xf2fde38b")  # transferOwnership(address)
+        assert anchor is not None
+        self.assertEqual(anchor.level, "HIGH")
+
+    def test_known_low_risk_selector(self) -> None:
+        anchor = lookup("0x8456cb59")  # pause()
+        assert anchor is not None
+        self.assertEqual(anchor.level, "LOW")
+
+    def test_case_insensitive(self) -> None:
+        self.assertIsNotNone(lookup("0xF2FDE38B"))
+
+    def test_unknown_selector_returns_none(self) -> None:
+        self.assertIsNone(lookup("0xdeadbeef"))
+
+    def test_empty_input(self) -> None:
+        self.assertIsNone(lookup(""))
+        self.assertIsNone(lookup("not-hex"))
+
+
+class TestFormatAnchorsBlock(unittest.TestCase):
+    def test_empty_input_returns_empty_string(self) -> None:
+        self.assertEqual(format_anchors_block([]), "")
+
+    def test_renders_signature_with_level_and_rationale(self) -> None:
+        anchor = RiskAnchor("HIGH", "replaces all code")
+        block = format_anchors_block([("upgradeTo(address)", anchor)])
+        self.assertIn("upgradeTo(address)", block)
+        self.assertIn("HIGH", block)
+        self.assertIn("replaces all code", block)
+
+    def test_renders_multiple_anchors(self) -> None:
+        block = format_anchors_block(
+            [
+                ("pause()", RiskAnchor("LOW", "defensive")),
+                ("transferOwnership(address)", RiskAnchor("HIGH", "full admin")),
+            ]
+        )
+        self.assertIn("pause()", block)
+        self.assertIn("transferOwnership(address)", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_context.py
+++ b/tests/test_source_context.py
@@ -8,6 +8,7 @@ from utils.source_context import (
     _extract_function_body,
     _extract_function_snippet,
     extract_state_var_snippet,
+    fetch_function_input_names,
     find_state_var_writes,
     get_contract_label,
     get_source_context,
@@ -329,6 +330,72 @@ class TestGetContractLabel(unittest.TestCase):
         }
         label = get_contract_label(1, "0xac21b22b5aeb11bc32de4ecf59e4538fca48b694")
         self.assertEqual(label, "FarmRegistry")
+
+
+class TestFetchFunctionInputNames(unittest.TestCase):
+    """ABI-driven parameter name extraction."""
+
+    def setUp(self) -> None:
+        reset_cache()
+
+    _SAMPLE_ABI = (
+        '[{"type":"function","name":"setMaxSlippage","inputs":[{"name":"_maxSlippage","type":"uint256"}],'
+        '"outputs":[],"stateMutability":"nonpayable"},'
+        '{"type":"function","name":"anonymousArgs","inputs":[{"name":"","type":"uint256"}],"outputs":[]},'
+        '{"type":"function","name":"noArgs","inputs":[],"outputs":[]}]'
+    )
+
+    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"})
+    @patch("utils.source_context.fetch_json")
+    def test_returns_named_inputs(self, mock_fetch: object) -> None:
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "status": "1",
+            "result": [{"SourceCode": "/* x */", "ContractName": "Farm", "ABI": self._SAMPLE_ABI}],
+        }
+        names = fetch_function_input_names(1, "0xabc", "setMaxSlippage")
+        self.assertEqual(names, ["_maxSlippage"])
+
+    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"})
+    @patch("utils.source_context.fetch_json")
+    def test_empty_inputs_for_noarg_function(self, mock_fetch: object) -> None:
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "status": "1",
+            "result": [{"SourceCode": "/* x */", "ContractName": "Farm", "ABI": self._SAMPLE_ABI}],
+        }
+        self.assertEqual(fetch_function_input_names(1, "0xabc", "noArgs"), [])
+
+    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"})
+    @patch("utils.source_context.fetch_json")
+    def test_returns_none_when_inputs_unnamed(self, mock_fetch: object) -> None:
+        # Mixing named + anonymous params is worse than nothing — return None
+        # so the formatter falls back to bare types for the whole signature.
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "status": "1",
+            "result": [{"SourceCode": "/* x */", "ContractName": "Farm", "ABI": self._SAMPLE_ABI}],
+        }
+        self.assertIsNone(fetch_function_input_names(1, "0xabc", "anonymousArgs"))
+
+    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"})
+    @patch("utils.source_context.fetch_json")
+    def test_returns_none_when_function_not_in_abi(self, mock_fetch: object) -> None:
+        mock_fetch.return_value = {  # type: ignore[attr-defined]
+            "status": "1",
+            "result": [{"SourceCode": "/* x */", "ContractName": "Farm", "ABI": self._SAMPLE_ABI}],
+        }
+        self.assertIsNone(fetch_function_input_names(1, "0xabc", "doesNotExist"))
+
+    @patch.dict("os.environ", {"ETHERSCAN_TOKEN": "test-key"})
+    @patch("utils.proxy.get_current_implementation")
+    @patch("utils.source_context.fetch_json")
+    def test_follows_proxy_to_impl_abi(self, mock_fetch: object, mock_impl: object) -> None:
+        proxy_abi = '[{"type":"function","name":"fallback","inputs":[]}]'
+        mock_fetch.side_effect = [  # type: ignore[attr-defined]
+            {"status": "1", "result": [{"SourceCode": "/* x */", "ContractName": "ERC1967Proxy", "ABI": proxy_abi}]},
+            {"status": "1", "result": [{"SourceCode": "/* x */", "ContractName": "Farm", "ABI": self._SAMPLE_ABI}]},
+        ]
+        mock_impl.return_value = "0x" + "11" * 20  # type: ignore[attr-defined]
+        names = fetch_function_input_names(1, "0xProxy", "setMaxSlippage")
+        self.assertEqual(names, ["_maxSlippage"])
 
 
 if __name__ == "__main__":

--- a/utils/address_resolver.py
+++ b/utils/address_resolver.py
@@ -1,0 +1,115 @@
+"""Resolve a contract address to a human-readable label.
+
+Single entry point for "what should I call this address?" The actual lookups
+fan out across several backends in priority order — first non-empty result
+wins. Backends are registered as a list so adding a new source (ENS reverse,
+Dune labels, internal yearn registry, …) is just appending one callable.
+
+Each backend is a callable ``(chain_id, address) -> str`` that returns
+either a usable label or ``""``. Exceptions are caught here so a broken
+backend can't take down the chain.
+"""
+
+from typing import Callable
+
+from utils.logging import get_logger
+
+logger = get_logger("utils.address_resolver")
+
+Backend = Callable[[int, str], str]
+
+
+def _safe_utility_backend(chain_id: int, address: str) -> str:
+    """Canonical Safe utilities (MultiSendCallOnly, SignMessageLib, …). No IO."""
+    from safe.multisend import safe_utility_label
+
+    return safe_utility_label(address)
+
+
+def _swiss_knife_backend(chain_id: int, address: str) -> str:
+    """Curated labels for well-known dApps from swiss-knife.xyz."""
+    from utils.swiss_knife import fetch_swiss_knife_labels, pick_display_name
+
+    return pick_display_name(fetch_swiss_knife_labels(address, chain_id))
+
+
+def _etherscan_backend(chain_id: int, address: str) -> str:
+    """Verified-contract ContractName, with EIP-1967 impl follow for generic proxies."""
+    from utils.source_context import (
+        _GENERIC_PROXY_NAMES,
+        fetch_source,
+    )
+
+    fetched = fetch_source(chain_id, address)
+    if not fetched:
+        return ""
+
+    name = fetched[0]
+    if name and name not in _GENERIC_PROXY_NAMES:
+        return name
+
+    from utils.proxy import get_current_implementation
+
+    impl = get_current_implementation(address, chain_id)
+    if not impl or impl.lower() == address.lower():
+        return name
+
+    impl_fetched = fetch_source(chain_id, impl)
+    if impl_fetched and impl_fetched[0]:
+        return impl_fetched[0]
+    return name
+
+
+# Resolution order, by backend name. Earlier wins when it returns a non-empty
+# label. Stored as names rather than function references so monkey-patching the
+# functions at test time (e.g. via `@patch("utils.address_resolver._swiss_knife_backend")`)
+# actually swaps what the chain calls. Also lets callers `register_backend` a
+# new function attached to this module and have it resolve correctly.
+_BACKEND_NAMES: list[str] = [
+    "_safe_utility_backend",
+    "_swiss_knife_backend",
+    "_etherscan_backend",
+]
+
+
+def resolve_address_label(chain_id: int, address: str) -> str:
+    """Best-effort human label for a contract address.
+
+    Tries each backend in order, returns the first non-empty result. A
+    failing backend (raised exception, network error) is skipped quietly
+    so a transient outage in one source doesn't break the others.
+    Returns ``""`` for EOAs, unverified contracts, or all-misses.
+    """
+    if not address:
+        return ""
+
+    module_globals = globals()
+    for name in _BACKEND_NAMES:
+        backend = module_globals.get(name)
+        if backend is None:
+            continue
+        try:
+            label = backend(chain_id, address)
+        except Exception as e:  # noqa: BLE001 - best-effort resolution
+            logger.info("Address-label backend %s failed for %s: %s", name, address, e)
+            continue
+        if label:
+            return label
+    return ""
+
+
+def register_backend(backend: Backend, position: int | None = None) -> None:
+    """Add a new resolution backend. ``position`` defaults to end-of-list.
+
+    The callable is attached to this module under its ``__name__`` so the
+    name-based lookup in :func:`resolve_address_label` finds it. Lower
+    position = higher priority.
+    """
+    name = backend.__name__
+    globals()[name] = backend
+    if name in _BACKEND_NAMES:
+        return
+    if position is None:
+        _BACKEND_NAMES.append(name)
+    else:
+        _BACKEND_NAMES.insert(position, name)

--- a/utils/calldata/decoder.py
+++ b/utils/calldata/decoder.py
@@ -1,9 +1,12 @@
 """Decode raw calldata into human-readable function calls.
 
 Uses a local lookup table for common selectors and falls back to the
-Sourcify 4byte signature database API for unknown ones.
+Sourcify 4byte signature database API for unknown ones. The Sourcify
+results are persisted between runs in a file-backed cache so each
+selector pays the lookup cost only once across all workflow invocations.
 """
 
+import os
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -17,11 +20,47 @@ from utils.logging import get_logger
 
 logger = get_logger("calldata_decoder")
 
-# In-memory cache: selector hex -> function signature or None
-_selector_cache: dict[str, str | None] = {}
-
 # Sourcify 4byte signature database (successor to openchain.xyz)
 _SELECTOR_LOOKUP_URL = "https://api.4byte.sourcify.dev/signature-database/v1/lookup"
+
+# Persistent selector cache: append-only file backing the in-memory dict so we
+# don't re-query Sourcify for the same selector on every cron run. Negative
+# results are stored too (Sourcify miss → __NONE__ sentinel) so we don't retry
+# selectors that aren't in any database. Format: one `selector|signature` per
+# line, pipe-delimited because ABI signatures don't contain pipes.
+_SELECTOR_CACHE_FILE = os.getenv("SELECTOR_CACHE_FILENAME", "selector-cache.txt")
+_NEGATIVE_SENTINEL = "__NONE__"
+
+
+def _load_selector_cache() -> dict[str, str | None]:
+    cache: dict[str, str | None] = {}
+    if not os.path.exists(_SELECTOR_CACHE_FILE):
+        return cache
+    try:
+        with open(_SELECTOR_CACHE_FILE, "r") as f:
+            for raw in f:
+                line = raw.rstrip("\n")
+                if "|" not in line:
+                    continue
+                sel, sig = line.split("|", 1)
+                cache[sel.lower()] = None if sig == _NEGATIVE_SENTINEL else sig
+    except OSError as e:
+        logger.warning("Failed to load selector cache %s: %s", _SELECTOR_CACHE_FILE, e)
+    return cache
+
+
+def _persist_selector(selector: str, signature: str | None) -> None:
+    """Append one selector→signature pair to the on-disk cache (best-effort)."""
+    try:
+        with open(_SELECTOR_CACHE_FILE, "a") as f:
+            f.write(f"{selector.lower()}|{signature or _NEGATIVE_SENTINEL}\n")
+    except OSError as e:
+        logger.debug("Failed to persist selector %s: %s", selector, e)
+
+
+# In-memory cache: selector hex -> function signature or None.
+# Bootstrapped from the on-disk cache so each workflow starts warm.
+_selector_cache: dict[str, str | None] = _load_selector_cache()
 
 
 @dataclass(frozen=True)
@@ -70,6 +109,7 @@ def resolve_selector(selector_hex: str) -> str | None:
     data = fetch_json(_SELECTOR_LOOKUP_URL, params={"function": selector_hex})
     if not data:
         _selector_cache[selector_hex] = None
+        _persist_selector(selector_hex, None)
         return None
 
     try:
@@ -77,11 +117,13 @@ def resolve_selector(selector_hex: str) -> str | None:
         if results and len(results) > 0:
             sig = results[0].get("name")
             _selector_cache[selector_hex] = sig
+            _persist_selector(selector_hex, sig)
             return sig
     except (AttributeError, IndexError, TypeError):
         pass
 
     _selector_cache[selector_hex] = None
+    _persist_selector(selector_hex, None)
     return None
 
 

--- a/utils/calldata/decoder.py
+++ b/utils/calldata/decoder.py
@@ -105,23 +105,40 @@ def resolve_selector(selector_hex: str) -> str | None:
     if selector_hex in _selector_cache:
         return _selector_cache[selector_hex]
 
-    # 3. Remote API fallback
+    # 3. Remote API fallback. Persist *only* when the response is structurally
+    # well-formed — a transient Sourcify failure (timeout, 5xx, 429, network
+    # blip) must NOT be written to the on-disk cache, because that file is
+    # shared across every workflow run via actions/cache. A single bad minute
+    # would otherwise blacklist a selector permanently across the CI fleet.
     data = fetch_json(_SELECTOR_LOOKUP_URL, params={"function": selector_hex})
-    if not data:
+    if not isinstance(data, dict):
+        # `fetch_json` returns None on HTTP error / timeout / network failure.
+        # Cache the miss in-memory (so we don't re-query within this run) but
+        # don't persist — let the next run retry.
         _selector_cache[selector_hex] = None
-        _persist_selector(selector_hex, None)
         return None
 
-    try:
-        results = data.get("result", {}).get("function", {}).get(selector_hex)
-        if results and len(results) > 0:
-            sig = results[0].get("name")
+    result_section = data.get("result")
+    function_section = result_section.get("function") if isinstance(result_section, dict) else None
+    if not isinstance(function_section, dict):
+        # Response didn't match Sourcify's documented shape. Treat as transient.
+        _selector_cache[selector_hex] = None
+        return None
+
+    results = function_section.get(selector_hex)
+    if results:
+        try:
+            sig = results[0].get("name") if isinstance(results[0], dict) else None
+        except (IndexError, AttributeError):
+            sig = None
+        if sig:
             _selector_cache[selector_hex] = sig
             _persist_selector(selector_hex, sig)
             return sig
-    except (AttributeError, IndexError, TypeError):
-        pass
 
+    # Well-formed response with no signature for this selector — Sourcify
+    # explicitly says "we don't know this one". Safe to persist so we skip
+    # the lookup on future runs.
     _selector_cache[selector_hex] = None
     _persist_selector(selector_hex, None)
     return None

--- a/utils/erc20_metadata.py
+++ b/utils/erc20_metadata.py
@@ -1,0 +1,75 @@
+"""Fetch ERC20 token metadata (symbol, decimals) for LLM prompt enrichment.
+
+Without this, the LLM sees raw amounts like ``transfer(0xUSDC, 1000000000)``
+and can't tell if that's $1 (6 decimals) or $1e-12 (18 decimals). Looking
+up ``symbol()`` and ``decimals()`` once per unique address lets us annotate
+the prompt with ``(USDC, 6 dec)`` so the model can compute concrete values.
+
+This is best-effort: any non-ERC20 address fails the eth_call cleanly and
+returns ``None``, treated as "no metadata available".
+"""
+
+from dataclasses import dataclass
+
+from eth_utils import to_checksum_address
+
+from utils.abi import load_abi
+from utils.chains import Chain
+from utils.logging import get_logger
+from utils.web3_wrapper import ChainManager
+
+logger = get_logger("utils.erc20_metadata")
+
+_ERC20_ABI = None  # loaded lazily on first call
+
+# Per-process cache: (chain_id, address_lower) -> ERC20Metadata or None for miss.
+_cache: dict[tuple[int, str], "ERC20Metadata | None"] = {}
+
+
+@dataclass(frozen=True)
+class ERC20Metadata:
+    """Decoded ERC20 token metadata."""
+
+    symbol: str
+    decimals: int
+
+
+def fetch_erc20_metadata(chain_id: int, address: str) -> ERC20Metadata | None:
+    """Return token metadata for an address, or None if it isn't ERC20-compatible.
+
+    Both ``symbol()`` and ``decimals()`` must succeed — partial responses are
+    treated as a miss. The pair is fetched via batch_requests so it costs a
+    single round-trip instead of two.
+    """
+    if not address or len(address) != 42 or not address.startswith("0x"):
+        return None
+
+    cache_key = (chain_id, address.lower())
+    if cache_key in _cache:
+        return _cache[cache_key]
+
+    global _ERC20_ABI
+    if _ERC20_ABI is None:
+        _ERC20_ABI = load_abi("common-abi/ERC20.json")
+
+    try:
+        chain = Chain.from_chain_id(chain_id)
+        client = ChainManager.get_client(chain)
+        token = client.get_contract(to_checksum_address(address), _ERC20_ABI)
+        with client.batch_requests() as batch:
+            batch.add(token.functions.symbol())
+            batch.add(token.functions.decimals())
+            symbol, decimals = client.execute_batch(batch)
+        meta = ERC20Metadata(symbol=str(symbol), decimals=int(decimals))
+    except Exception as e:  # noqa: BLE001 - any eth_call failure -> not an ERC20
+        logger.debug("ERC20 metadata fetch failed for %s on chain %s: %s", address, chain_id, e)
+        _cache[cache_key] = None
+        return None
+
+    _cache[cache_key] = meta
+    return meta
+
+
+def reset_cache() -> None:
+    """Reset the in-memory metadata cache. Useful for tests."""
+    _cache.clear()

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from eth_utils import to_checksum_address
 
 from utils.calldata.decoder import DecodedCall, decode_calldata, is_selector_resolvable_offline
+from utils.erc20_metadata import fetch_erc20_metadata
 from utils.impl_diff import diff_implementations, format_impl_diff
 from utils.llm import get_llm_provider
 from utils.llm.base import LLMError
@@ -17,6 +18,8 @@ from utils.logging import get_logger
 from utils.on_chain_state import StateRead, format_state_reads, read_before_state
 from utils.paste import upload_to_paste
 from utils.proxy import build_diff_url, detect_proxy_upgrade, get_current_implementation
+from utils.risk_anchors import format_anchors_block
+from utils.risk_anchors import lookup as lookup_risk_anchor
 from utils.source_context import (
     SourceContext,
     fetch_function_input_names,
@@ -57,7 +60,10 @@ Critical rules for parameter interpretation:
 - When a Current State section is provided, quote concrete before→after deltas.
 - If a unit is ambiguous and no source context resolves it, say so explicitly rather than
   guessing. Quote the raw value plus its 1e18-normalized form.
-- Never assign HIGH/CRITICAL risk on the basis of a guessed unit interpretation."""
+- Never assign HIGH/CRITICAL risk on the basis of a guessed unit interpretation.
+- When a Risk Anchors section is provided, treat it as a typical floor/ceiling, not a
+  verdict. Adjust up or down based on the specific parameters (e.g. grantRole of a
+  minor role can be LOW; an upgrade to fresh-bytecode code can be CRITICAL)."""
 
 FORMAT_REMINDER = """
 Format your response exactly as:
@@ -267,6 +273,20 @@ def _checksum_or_none(addr: str) -> str | None:
         return None
 
 
+def _annotate_target_line(target: str, labels: dict[str, str]) -> str:
+    """Annotate the ``Target:`` line — works for single addresses and batch lists.
+
+    Batch entry points pass a comma-joined target string; we annotate each
+    item independently so the LLM sees per-target labels rather than one
+    confusing blob.
+    """
+    if not target:
+        return target
+    if "," not in target:
+        return _annotate_address(target, labels)
+    return ", ".join(_annotate_address(part.strip(), labels) for part in target.split(","))
+
+
 def _annotate_address(addr: str, labels: dict[str, str]) -> str:
     """Render a single address with an optional `(ContractName)` suffix."""
     checksum = _checksum_or_none(addr)
@@ -300,38 +320,54 @@ def _collect_address_labels(
     targets_and_calls: list[tuple[str, DecodedCall]],
     chain_id: int,
 ) -> dict[str, str]:
-    """Look up `{checksum_address: contract_name}` for every address-typed argument.
+    """Look up `{checksum_address: contract_name}` for every relevant address.
 
-    Skips each call's own target — its name is already surfaced via Contract
-    Source Context. Lookups run concurrently so a batch alert with N
-    distinct addresses doesn't pay N × ~3s serially. Best-effort: any
-    lookup failure is silently dropped.
+    Includes each call's own target (so the prompt can annotate the
+    ``Target: …`` line — especially useful when the target is an ERC20
+    and the decimals matter) plus every address-typed argument. Lookups
+    run concurrently so a batch alert with N distinct addresses doesn't
+    pay N × ~3s serially. Best-effort: any lookup failure is silently dropped.
     """
-    target_lower = {tgt.lower() for tgt, _ in targets_and_calls if tgt}
     seen: set[str] = set()
     candidates: list[str] = []  # checksum addresses to look up
-    for _, decoded in targets_and_calls:
+
+    def _consider(raw: str) -> None:
+        addr_lower = raw.lower()
+        if addr_lower in seen:
+            return
+        seen.add(addr_lower)
+        if len(addr_lower) != 42 or int(addr_lower, 16) == 0:
+            return
+        checksum = _checksum_or_none(raw)
+        if checksum is None:
+            return
+        candidates.append(checksum)
+
+    for target, decoded in targets_and_calls:
+        if target:
+            _consider(target)
         for raw in _extract_address_args(decoded):
-            addr_lower = raw.lower()
-            if addr_lower in seen:
-                continue
-            seen.add(addr_lower)
-            if addr_lower in target_lower:
-                continue
-            if len(addr_lower) != 42 or int(addr_lower, 16) == 0:
-                continue
-            checksum = _checksum_or_none(raw)
-            if checksum is None:
-                continue
-            candidates.append(checksum)
+            _consider(raw)
 
     def fetch(checksum: str) -> tuple[str, str] | None:
         try:
-            label = get_contract_label(chain_id, checksum)
+            base = get_contract_label(chain_id, checksum)
         except Exception as e:  # noqa: BLE001 - best-effort enrichment
             logger.info("Contract label fetch failed for %s: %s", checksum, e)
             return None
-        return (checksum, label) if label else None
+        # Augment with ERC20 metadata when applicable. The eth_call is best-effort
+        # and cached — non-token addresses fail fast and produce no annotation.
+        try:
+            meta = fetch_erc20_metadata(chain_id, checksum)
+        except Exception as e:  # noqa: BLE001
+            logger.info("ERC20 metadata fetch failed for %s: %s", checksum, e)
+            meta = None
+        if meta:
+            decorated = (
+                f"{base} ({meta.symbol}, {meta.decimals} dec)" if base else f"{meta.symbol}, {meta.decimals} dec"
+            )
+            return (checksum, decorated)
+        return (checksum, base) if base else None
 
     results = _parallel_map(fetch, candidates)
     return {checksum: label for entry in results if entry for checksum, label in [entry]}
@@ -379,6 +415,33 @@ def _try_decode_inner_bytes(value: object) -> DecodedCall | None:
         return decode_calldata(hex_str)
     except (ValueError, TypeError):
         return None
+
+
+def _collect_risk_anchors(decoded_calls: list[DecodedCall]) -> str:
+    """Build the Risk Anchors prompt section for calls with known anchors.
+
+    Deduped by signature so a 5-call batch of identical setCoverageCap calls
+    surfaces a single line rather than five. Returns "" if no call in the
+    batch has a registered anchor.
+    """
+    seen: set[str] = set()
+    anchored: list[tuple[str, object]] = []
+    for call in decoded_calls:
+        if call.signature in seen:
+            continue
+        # The decoder normalizes signatures to the 4byte-selector text form, so
+        # we re-compute the selector locally rather than carrying it through.
+        from eth_utils import function_signature_to_4byte_selector
+
+        try:
+            sel = "0x" + function_signature_to_4byte_selector(call.signature).hex()
+        except Exception:  # noqa: BLE001 - bad signatures are skipped
+            continue
+        anchor = lookup_risk_anchor(sel)
+        if anchor:
+            anchored.append((call.signature, anchor))
+            seen.add(call.signature)
+    return format_anchors_block(anchored)
 
 
 def _collect_param_names(
@@ -524,7 +587,10 @@ def _build_prompt(
         parts.append(f"Protocol: {protocol}")
     if label:
         parts.append(f"Contract: {label}")
-    parts.append(f"Target: {target}")
+    # Annotate the target with any label we have for it (token symbol/decimals,
+    # protocol name). For batch alerts this is a comma-joined list — we
+    # annotate the individual addresses, not the whole string.
+    parts.append(f"Target: {_annotate_target_line(target, address_labels or {})}")
     if value > 0:
         parts.append(f"ETH Value: {value / 1e18:.6f} ETH")
 
@@ -552,6 +618,10 @@ def _build_prompt(
 
     if proxy_upgrade_info:
         parts.append(f"\n--- Proxy Upgrade ---\n{proxy_upgrade_info}")
+
+    risk_anchors = _collect_risk_anchors(decoded_calls)
+    if risk_anchors:
+        parts.append(f"\n--- Risk Anchors ---\n{risk_anchors}")
 
     if simulation:
         parts.append(f"\n--- Simulation Results ---\n{_format_simulation_context(simulation)}")

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -17,7 +17,13 @@ from utils.logging import get_logger
 from utils.on_chain_state import StateRead, format_state_reads, read_before_state
 from utils.paste import upload_to_paste
 from utils.proxy import build_diff_url, detect_proxy_upgrade, get_current_implementation
-from utils.source_context import SourceContext, format_source_context, get_contract_label, get_source_context
+from utils.source_context import (
+    SourceContext,
+    fetch_function_input_names,
+    format_source_context,
+    get_contract_label,
+    get_source_context,
+)
 from utils.telegram import escape_markdown
 from utils.tenderly.simulation import SimulationResult, simulate_transaction
 
@@ -159,17 +165,51 @@ def _format_batch_param_constants(decoded_calls: list[DecodedCall]) -> str:
     return "\n".join(notes)
 
 
+def _parallel_map(fn, items: list, max_workers: int = 8) -> list:
+    """Run ``fn`` over ``items`` concurrently, preserving input order.
+
+    Returns a list of results aligned with ``items``. Used to fan out
+    independent HTTP-bound lookups (Etherscan source, Swiss Knife labels,
+    ABI fetches) so a batch alert with N addresses doesn't pay N × ~3s
+    serially. Each item is wrapped in try/except so a single failure is
+    isolated.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    if not items:
+        return []
+    if len(items) == 1:
+        # No point spinning up a thread pool for a single call.
+        try:
+            return [fn(items[0])]
+        except Exception:  # noqa: BLE001
+            return [None]
+
+    results: list = [None] * len(items)
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(items))) as pool:
+        future_to_idx = {pool.submit(fn, item): i for i, item in enumerate(items)}
+        for future in future_to_idx:
+            idx = future_to_idx[future]
+            try:
+                results[idx] = future.result()
+            except Exception as e:  # noqa: BLE001
+                logger.info("Parallel lookup failed at index %d: %s", idx, e)
+                results[idx] = None
+    return results
+
+
 def _collect_source_contexts(
     targets_and_calls: list[tuple[str, DecodedCall]],
     chain_id: int,
 ) -> list[SourceContext]:
     """Fetch source context for each (target, decoded_call) pair, best-effort.
 
-    Deduplicates by (target, function_name). Silent on failure so a missing
-    Etherscan key or unverified contract never blocks an explanation.
+    Deduplicates by (target, function_name) then fans out the Etherscan
+    lookups in parallel. Silent on failure so a missing Etherscan key or
+    unverified contract never blocks an explanation.
     """
-    contexts: list[SourceContext] = []
     seen: set[tuple[str, str]] = set()
+    unique: list[tuple[str, str]] = []
     for target, decoded in targets_and_calls:
         if not target or not decoded.function_name:
             continue
@@ -177,14 +217,17 @@ def _collect_source_contexts(
         if key in seen:
             continue
         seen.add(key)
+        unique.append((target, decoded.function_name))
+
+    def fetch(item: tuple[str, str]) -> SourceContext | None:
+        target, fname = item
         try:
-            ctx = get_source_context(chain_id, target, decoded.function_name)
+            return get_source_context(chain_id, target, fname)
         except Exception as e:  # noqa: BLE001
-            logger.info("Source context fetch failed for %s.%s: %s", target, decoded.function_name, e)
-            continue
-        if ctx:
-            contexts.append(ctx)
-    return contexts
+            logger.info("Source context fetch failed for %s.%s: %s", target, fname, e)
+            return None
+
+    return [ctx for ctx in _parallel_map(fetch, unique) if ctx is not None]
 
 
 def _get_proxy_upgrade_info(calldata: str, target: str, chain_id: int) -> str:
@@ -260,12 +303,13 @@ def _collect_address_labels(
     """Look up `{checksum_address: contract_name}` for every address-typed argument.
 
     Skips each call's own target — its name is already surfaced via Contract
-    Source Context. Best-effort: any lookup failure is silently dropped.
+    Source Context. Lookups run concurrently so a batch alert with N
+    distinct addresses doesn't pay N × ~3s serially. Best-effort: any
+    lookup failure is silently dropped.
     """
     target_lower = {tgt.lower() for tgt, _ in targets_and_calls if tgt}
     seen: set[str] = set()
-    labels: dict[str, str] = {}
-
+    candidates: list[str] = []  # checksum addresses to look up
     for _, decoded in targets_and_calls:
         for raw in _extract_address_args(decoded):
             addr_lower = raw.lower()
@@ -274,20 +318,23 @@ def _collect_address_labels(
             seen.add(addr_lower)
             if addr_lower in target_lower:
                 continue
-            # Skip malformed / zero addresses — no point asking Etherscan.
             if len(addr_lower) != 42 or int(addr_lower, 16) == 0:
                 continue
             checksum = _checksum_or_none(raw)
             if checksum is None:
                 continue
-            try:
-                label = get_contract_label(chain_id, checksum)
-            except Exception as e:  # noqa: BLE001 - best-effort enrichment
-                logger.info("Contract label fetch failed for %s: %s", checksum, e)
-                continue
-            if label:
-                labels[checksum] = label
-    return labels
+            candidates.append(checksum)
+
+    def fetch(checksum: str) -> tuple[str, str] | None:
+        try:
+            label = get_contract_label(chain_id, checksum)
+        except Exception as e:  # noqa: BLE001 - best-effort enrichment
+            logger.info("Contract label fetch failed for %s: %s", checksum, e)
+            return None
+        return (checksum, label) if label else None
+
+    results = _parallel_map(fetch, candidates)
+    return {checksum: label for entry in results if entry for checksum, label in [entry]}
 
 
 _MAX_BYTES_RECURSION_DEPTH = 2
@@ -334,9 +381,42 @@ def _try_decode_inner_bytes(value: object) -> DecodedCall | None:
         return None
 
 
+def _collect_param_names(
+    targets_and_calls: list[tuple[str, DecodedCall]],
+    chain_id: int,
+) -> list[list[str] | None]:
+    """For each (target, call) pair, fetch parameter names from the verified ABI.
+
+    Returns a list aligned with the input. Entries are ``None`` when the
+    function isn't found or any parameter is unnamed (better to show bare
+    types than partially-labeled ones). Fans out in parallel; cached via
+    the same Etherscan call that powers `fetch_source`, so when source
+    context has already been collected for the same target the ABI call
+    is a cache hit and free.
+    """
+
+    def fetch(item: tuple[str, DecodedCall]) -> list[str] | None:
+        target, decoded = item
+        if not target or not decoded.function_name:
+            return None
+        try:
+            return fetch_function_input_names(chain_id, target, decoded.function_name)
+        except Exception as e:  # noqa: BLE001 - best-effort enrichment
+            logger.info("Param name fetch failed for %s.%s: %s", target, decoded.function_name, e)
+            return None
+
+    return _parallel_map(fetch, list(targets_and_calls))
+
+
+def _param_label(type_str: str, name: str | None) -> str:
+    """Render a Solidity-style ``type name`` declaration, falling back to bare type."""
+    return f"{type_str} {name}" if name else type_str
+
+
 def _format_decoded_calls(
     calls: list[DecodedCall],
     address_labels: dict[str, str] | None = None,
+    param_names_per_call: list[list[str] | None] | None = None,
     _depth: int = 0,
     _indent: str = "  ",
 ) -> str:
@@ -345,6 +425,12 @@ def _format_decoded_calls(
     When ``address_labels`` is provided, address arguments (including elements
     of ``address[]``) are annotated with their contract name so the LLM can
     refer to "MorphoFarm" instead of "0xac21...".
+
+    When ``param_names_per_call`` is provided (aligned 1:1 with ``calls``),
+    each parameter is rendered as ``type name: value`` instead of bare
+    ``type: value`` so the LLM sees ``uint256 _maxSlippage: …`` rather than
+    just ``uint256: …``. Nested (recursed) calls don't use this since their
+    target ABI isn't known.
 
     ``bytes`` parameters that themselves contain a known function call (e.g.
     ``upgradeToAndCall``'s init payload, governor ``execute(target,data)``
@@ -356,25 +442,28 @@ def _format_decoded_calls(
     parts: list[str] = []
     nested_indent = _indent + "    "
     for i, call in enumerate(calls):
+        names = (param_names_per_call or [None] * len(calls))[i] if _depth == 0 else None
         lines = [f"{_indent}Call {i + 1}: {call.signature}"] if _depth else [f"Call {i + 1}: {call.signature}"]
-        for type_str, value in call.params:
+        for j, (type_str, value) in enumerate(call.params):
+            name = names[j] if names is not None and j < len(names) else None
+            label = _param_label(type_str, name)
             if type_str == "address":
-                lines.append(f"{_indent}  {type_str}: {_annotate_address(value, labels)}")
+                lines.append(f"{_indent}  {label}: {_annotate_address(value, labels)}")
             elif type_str.startswith("address[") and isinstance(value, (list, tuple)):
                 if not value:
-                    lines.append(f"{_indent}  {type_str}: []")
+                    lines.append(f"{_indent}  {label}: []")
                 else:
-                    lines.append(f"{_indent}  {type_str}:")
+                    lines.append(f"{_indent}  {label}:")
                     lines.extend(f"{_indent}    - {_annotate_address(v, labels)}" for v in value)
             elif type_str == "bytes" and _depth < _MAX_BYTES_RECURSION_DEPTH:
                 inner = _try_decode_inner_bytes(value)
                 if inner:
-                    lines.append(f"{_indent}  {type_str}: ↳")
+                    lines.append(f"{_indent}  {label}: ↳")
                     lines.append(_format_decoded_calls([inner], labels, _depth=_depth + 1, _indent=nested_indent))
                 else:
-                    lines.append(f"{_indent}  {type_str}: {value}")
+                    lines.append(f"{_indent}  {label}: {value}")
             else:
-                lines.append(f"{_indent}  {type_str}: {value}")
+                lines.append(f"{_indent}  {label}: {value}")
         parts.append("\n".join(lines))
     return "\n\n".join(parts)
 
@@ -426,6 +515,7 @@ def _build_prompt(
     context_note: str = "",
     state_reads: list[tuple[str, list[StateRead]]] | None = None,
     address_labels: dict[str, str] | None = None,
+    param_names_per_call: list[list[str] | None] | None = None,
 ) -> str:
     """Build the full prompt for the LLM."""
     parts: list[str] = [SYSTEM_PROMPT, ""]
@@ -441,7 +531,9 @@ def _build_prompt(
     if context_note:
         parts.append(f"\n--- Execution Context ---\n{context_note}")
 
-    parts.append(f"\n--- Decoded Calldata ---\n{_format_decoded_calls(decoded_calls, address_labels)}")
+    parts.append(
+        f"\n--- Decoded Calldata ---\n{_format_decoded_calls(decoded_calls, address_labels, param_names_per_call)}"
+    )
 
     constants_note = _format_batch_param_constants(decoded_calls)
     if constants_note:
@@ -600,6 +692,7 @@ def explain_transaction(
     source_contexts = _collect_source_contexts([(target, decoded)], chain_id)
     state_reads = _collect_state_reads([(target, decoded)], chain_id)
     address_labels = _collect_address_labels([(target, decoded)], chain_id)
+    param_names = _collect_param_names([(target, decoded)], chain_id)
 
     simulation: SimulationResult | None = None
     if not skip_simulation:
@@ -634,6 +727,7 @@ def explain_transaction(
         context_note=context_note,
         state_reads=state_reads,
         address_labels=address_labels,
+        param_names_per_call=param_names,
     )
     logger.info("Full AI context for %s:\n%s", target, prompt)
 
@@ -728,6 +822,7 @@ def explain_batch_transaction(
     source_contexts = _collect_source_contexts(decoded_with_target, chain_id)
     state_reads = _collect_state_reads(decoded_with_target, chain_id)
     address_labels = _collect_address_labels(decoded_with_target, chain_id)
+    param_names = _collect_param_names(decoded_with_target, chain_id)
 
     targets = ", ".join(c.get("target", "?") for c in calls)
     total_value = sum(int(c.get("value", "0")) for c in calls)
@@ -744,6 +839,7 @@ def explain_batch_transaction(
         context_note=context_note,
         state_reads=state_reads,
         address_labels=address_labels,
+        param_names_per_call=param_names,
     )
     logger.info("Full AI context for batch (%s calls):\n%s", len(calls), prompt)
 

--- a/utils/risk_anchors.py
+++ b/utils/risk_anchors.py
@@ -1,0 +1,70 @@
+"""Risk anchors — offline floors for known dangerous/safe function selectors.
+
+The LLM picks LOW/MEDIUM/HIGH/CRITICAL from scratch every alert. That makes the
+same call land at different levels on different runs ("setMaxSlippage" → LOW
+one day, MEDIUM the next). Anchoring well-understood operations to a typical
+risk level stabilizes verdicts and gives the LLM a reference frame.
+
+These are *anchors*, not verdicts. The LLM is instructed to start from the
+anchor and adjust based on parameters. A grantRole call for the PAUSER role
+to a known multisig isn't HIGH; an upgrade of a vault to a fresh-bytecode
+implementation isn't LOW.
+
+Skipped intentionally:
+- ERC20 transfer/approve — too context-dependent (rewards distribution vs
+  exit liquidity look identical).
+- Generic timelock schedule/execute — the inner call is the thing being
+  judged, not the wrapper.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RiskAnchor:
+    """Typical risk level + one-line rationale for the LLM."""
+
+    level: str  # LOW / MEDIUM / HIGH / CRITICAL
+    rationale: str
+
+
+# Selector → RiskAnchor. Lowercase, with 0x prefix to match the decoder's format.
+_ANCHORS: dict[str, RiskAnchor] = {
+    # Pausing — reversible, defensive
+    "0x8456cb59": RiskAnchor("LOW", "pause() is a defensive emergency stop; reversible"),
+    "0x3f4ba83a": RiskAnchor("LOW", "unpause() restores normal operation"),
+    # Access control — depends on which role/who, but the operation itself is high-trust
+    "0x2f2ff15d": RiskAnchor("MEDIUM", "grantRole(): elevate to HIGH if role is owner/admin/upgrader"),
+    "0xd547741f": RiskAnchor("MEDIUM", "revokeRole(): elevate to HIGH if removing an emergency role"),
+    "0x36568abe": RiskAnchor("LOW", "renounceRole() permanently drops a privilege; usually defensive"),
+    # Ownership — irreversible authority change
+    "0xf2fde38b": RiskAnchor("HIGH", "transferOwnership(): hands over full admin control"),
+    "0x715018a6": RiskAnchor("HIGH", "renounceOwnership(): irrevocably abandons admin"),
+    # Proxy upgrades — replaces all code; impl-diff section should drive the verdict
+    "0x3659cfe6": RiskAnchor("HIGH", "upgradeTo(): replaces all implementation code"),
+    "0x4f1ef286": RiskAnchor("HIGH", "upgradeToAndCall(): replaces code AND runs initializer"),
+    "0x9623609d": RiskAnchor("HIGH", "upgradeAndCall() via ProxyAdmin: same as above, routed via admin"),
+    # Admin parameter changes
+    "0xe177246e": RiskAnchor("MEDIUM", "setDelay(): timelock window change — direction & magnitude matter"),
+    "0x4dd18bf5": RiskAnchor("MEDIUM", "setPendingAdmin(): new admin candidate — confirm + accept needed"),
+    "0x0e18b681": RiskAnchor("HIGH", "acceptAdmin(): completes an admin handover"),
+    # Diamond / facet operations
+    "0x1f931c1c": RiskAnchor("HIGH", "diamondCut(): replaces/adds/removes selectors — bytecode-level change"),
+}
+
+
+def lookup(selector_hex: str) -> RiskAnchor | None:
+    """Return the risk anchor for a selector, or None if no anchor is registered."""
+    if not selector_hex or not selector_hex.startswith("0x"):
+        return None
+    return _ANCHORS.get(selector_hex.lower())
+
+
+def format_anchors_block(signatures_and_anchors: list[tuple[str, RiskAnchor]]) -> str:
+    """Render a prompt-ready section listing the anchors for the current calls."""
+    if not signatures_and_anchors:
+        return ""
+    lines = ["These calls have observed risk profiles. Start from the anchor and adjust based on parameters."]
+    for sig, anchor in signatures_and_anchors:
+        lines.append(f"- {sig} → typically {anchor.level} ({anchor.rationale})")
+    return "\n".join(lines)

--- a/utils/source_context.py
+++ b/utils/source_context.py
@@ -24,9 +24,11 @@ ETHERSCAN_V2_API_URL = "https://api.etherscan.io/v2/api"
 # always under a few hundred chars in practice.
 MAX_SNIPPET_CHARS = 4000
 
-# Per-process cache: (chain_id, address_lower) -> (contract_name, source) or None for miss.
-# Workflows are short-lived so a process-lifetime dict is sufficient.
-_source_cache: dict[tuple[int, str], tuple[str, str] | None] = {}
+# Per-process cache: (chain_id, address_lower) -> (contract_name, source, abi_json_string)
+# or None for miss. Workflows are short-lived so a process-lifetime dict is sufficient.
+# The ABI is stored as the raw JSON string from Etherscan and parsed lazily by callers
+# that need it — keeps the cache small for the common case where only source is read.
+_source_cache: dict[tuple[int, str], tuple[str, str, str] | None] = {}
 
 _NATSPEC_LINE = r"(?:[ \t]*///.*\n|[ \t]*\*[^/].*\n|[ \t]*/\*\*[\s\S]*?\*/[ \t]*\n)"
 _NATSPEC_BLOCK = rf"(?:(?:{_NATSPEC_LINE})+)?"
@@ -67,12 +69,11 @@ class SourceContext:
     state_var_snippets: list[str]  # natspec + declaration for each mutated state var
 
 
-def fetch_source(chain_id: int, address: str) -> tuple[str, str] | None:
-    """Fetch (contract_name, concatenated_source) for a verified contract.
+def _fetch_etherscan_contract(chain_id: int, address: str) -> tuple[str, str, str] | None:
+    """Internal: fetch and cache (contract_name, source, abi_json_string).
 
-    Returns None if the API key is missing, the contract is unverified, or the
-    request fails. Caches by (chain_id, address) so repeated calls during the
-    same run hit the API only once.
+    Single Etherscan call shared by `fetch_source` (for natspec) and
+    `fetch_function_input_names` (for parameter labels).
     """
     api_key = os.getenv("ETHERSCAN_TOKEN")
     if not api_key:
@@ -98,9 +99,90 @@ def fetch_source(chain_id: int, address: str) -> tuple[str, str] | None:
         _source_cache[cache_key] = None
         return None
 
-    result = (entry.get("ContractName") or "", _concat_sources(raw_source))
+    result = (
+        entry.get("ContractName") or "",
+        _concat_sources(raw_source),
+        entry.get("ABI") or "",
+    )
     _source_cache[cache_key] = result
     return result
+
+
+def fetch_source(chain_id: int, address: str) -> tuple[str, str] | None:
+    """Fetch (contract_name, concatenated_source) for a verified contract.
+
+    Returns None if the API key is missing, the contract is unverified, or the
+    request fails. Caches by (chain_id, address) so repeated calls during the
+    same run hit the API only once.
+    """
+    record = _fetch_etherscan_contract(chain_id, address)
+    return None if record is None else (record[0], record[1])
+
+
+def _parse_abi(abi_json: str) -> list[dict] | None:
+    """Parse Etherscan's ABI string. Returns None for unverified/malformed."""
+    if not abi_json or abi_json == "Contract source code not verified":
+        return None
+    try:
+        parsed = json.loads(abi_json)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, list) else None
+
+
+def fetch_function_input_names(chain_id: int, address: str, function_name: str) -> list[str] | None:
+    """Return parameter names for ``function_name`` on the verified ABI, or None.
+
+    Used by the explainer to render decoded calldata with named parameters
+    (``_maxSlippage: 95e16``) instead of bare types (``uint256: 95e16``).
+    Follows EIP-1967 to the implementation when the target is a generic
+    proxy — the proxy's ABI has the proxy's own functions, not the impl's.
+    """
+    record = _fetch_etherscan_contract(chain_id, address)
+    if record is None:
+        return None
+
+    names = _function_input_names_from_abi(record[2], function_name)
+    if names is not None:
+        return names
+
+    # Function isn't in target ABI — try the impl if this is a generic proxy.
+    if record[0] and record[0] not in _GENERIC_PROXY_NAMES:
+        return None
+
+    from utils.proxy import get_current_implementation
+
+    impl = get_current_implementation(address, chain_id)
+    if not impl or impl.lower() == address.lower():
+        return None
+    impl_record = _fetch_etherscan_contract(chain_id, impl)
+    if impl_record is None:
+        return None
+    return _function_input_names_from_abi(impl_record[2], function_name)
+
+
+def _function_input_names_from_abi(abi_json: str, function_name: str) -> list[str] | None:
+    """Pull input names for ``function_name`` out of an ABI JSON string.
+
+    Returns ``None`` if the function isn't present; an empty list if the
+    function has no parameters. If any input is unnamed (anonymous param),
+    return ``None`` rather than a mix — the LLM is better off without than
+    with partial labels.
+    """
+    abi = _parse_abi(abi_json)
+    if abi is None:
+        return None
+    for entry in abi:
+        if not isinstance(entry, dict) or entry.get("type") != "function":
+            continue
+        if entry.get("name") != function_name:
+            continue
+        inputs = entry.get("inputs") or []
+        names = [(inp.get("name") or "") for inp in inputs if isinstance(inp, dict)]
+        if any(not n for n in names):
+            return None
+        return names
+    return None
 
 
 def _concat_sources(raw_source: str) -> str:
@@ -253,53 +335,12 @@ def get_source_context(chain_id: int, address: str, function_name: str) -> Sourc
 def get_contract_label(chain_id: int, address: str) -> str:
     """Best-effort human label for a contract address.
 
-    Resolution order:
-      1. Safe utility registry (no API call) — covers MultiSendCallOnly etc.
-      2. Etherscan ContractName for the address.
-      3. If that name is a generic proxy wrapper, follow EIP-1967 to the impl
-         and use the impl's contract name instead.
-
-    Returns "" for EOAs, unverified contracts, missing API key, or any failure.
+    Thin compatibility wrapper around :func:`utils.address_resolver.resolve_address_label`.
+    Kept here so existing imports (and tests that patch this name) continue to work.
     """
-    if not address:
-        return ""
+    from utils.address_resolver import resolve_address_label
 
-    # Lazy import to keep utils/source_context.py free of safe/ dependencies at
-    # module load time (and to avoid a cycle if safe ever imports from here).
-    from safe.multisend import safe_utility_label
-
-    cheap = safe_utility_label(address)
-    if cheap:
-        return cheap
-
-    # Swiss Knife has curated labels for well-known protocol contracts
-    # (Circle: USDC Token, Uniswap V3 Router, etc.) — much richer than the
-    # Etherscan ContractName for those. High precision, low recall, so we
-    # fall through to Etherscan for the long tail of custom contracts.
-    from utils.swiss_knife import fetch_swiss_knife_labels, pick_display_name
-
-    sk_name = pick_display_name(fetch_swiss_knife_labels(address, chain_id))
-    if sk_name:
-        return sk_name
-
-    fetched = fetch_source(chain_id, address)
-    if not fetched:
-        return ""
-
-    name = fetched[0]
-    if name and name not in _GENERIC_PROXY_NAMES:
-        return name
-
-    from utils.proxy import get_current_implementation
-
-    impl = get_current_implementation(address, chain_id)
-    if not impl or impl.lower() == address.lower():
-        return name
-
-    impl_fetched = fetch_source(chain_id, impl)
-    if impl_fetched and impl_fetched[0]:
-        return impl_fetched[0]
-    return name
+    return resolve_address_label(chain_id, address)
 
 
 def format_source_context(ctx: SourceContext) -> str:


### PR DESCRIPTION
Stacks on top of #233. Six improvements that compound, plus a CI commit so the persistent cache actually persists.

## 1. Persistent selector cache (`5e1c78d`)

Sourcify lookups used to die with the process. Now appended to `selector-cache.txt` (env var `SELECTOR_CACHE_FILENAME` to override) and loaded on import. Negative results persisted too, so unknown selectors don't retry their 30s timeout on every cron run. Compounds with #233's offline-selector gate.

## 2. Address resolver module + ABI fetcher (`b50050e`)

Three label sources (Safe utility, Swiss Knife, Etherscan + proxy follow) used to be tangled inside `get_contract_label`. Extracted to `utils/address_resolver.py` with a backend-list pattern — adding a fourth source is now just appending a callable. `get_contract_label` stays as a thin compatibility wrapper.

Same commit adds `fetch_function_input_names(chain_id, address, function_name)` because it shares the Etherscan `getsourcecode` call we were throwing half away. Also a `tests/conftest.py` autouse fixture that blocks accidental live API calls.

## 3. Named parameters + parallel lookups (`b680ba6`)

Prompt now shows `uint256 _maxSlippage: 950000000000000000` instead of bare `uint256: …`. Falls back cleanly to bare types when the ABI is missing.

`_parallel_map` fans out the label/source/ABI lookups via `ThreadPoolExecutor` (max 8 workers, order-preserving). A 10-address batch alert goes from ~50s cold-cache to ~6s.

## 4. ERC20 metadata + risk anchors (`6ed473d`)

**ERC20 metadata**: when an address resolves as a token, `(SYMBOL, N dec)` is appended to its label. The `Target:` line shows it too — so a `transfer` proposal's prompt makes decimals immediately visible. One batched eth_call for `symbol()` + `decimals()`, cached, fails fast for non-tokens.

**Risk anchors**: a small offline registry maps known-load-bearing selectors (transferOwnership, upgradeToAndCall, pause, grantRole, diamondCut, etc.) to a typical risk level + rationale. `--- Risk Anchors ---` section in the prompt; SYSTEM_PROMPT tells the LLM to treat them as a starting point, not a verdict. Stabilizes the LOW/MEDIUM/HIGH/CRITICAL choice across runs.

## 5. Test hygiene (`3ca6c3b`)

Six pre-existing `TestAddressLabels` tests didn't mock `fetch_erc20_metadata` (which #4 added as a new dependency). On developer machines with `PROVIDER_URL_*` set they hung for 30s+ hitting real RPC. Added the missing `@patch` to each; reframed the conftest fixture as honest defense-in-depth rather than a load-bearing crutch.

## 6. CI cache persistence (`6035c90`)

Without this, commit #1 was misleadingly named in production: each GitHub Actions runner starts with a fresh filesystem, so `selector-cache.txt` was empty at the top of every cron run.

Extends `_run-monitoring.yml` to restore/save it via `actions/cache@v5`, alongside the existing per-workflow `cache_file` handling. One shared key `selector-cache-v1` across every calling workflow because selectors are chain-agnostic — the hourly run's Sourcify hit is equally valid for multisig-checker, timelock alerts, etc. Concurrent saves handled by actions/cache's first-writer-wins semantics.

## Test plan
- [x] `uv run pytest tests/ -q` → 332 passing (1 pre-existing telegram failure unchanged)
- [x] `ruff format --check .` / `ruff check .` clean
- [ ] After merge: confirm `Cache restored from key: selector-cache-v1-…` shows up in workflow logs after the first cron run completes
- [ ] Live e2e on a token-flow proposal — verify the AI summary computes concrete amounts
- [ ] Live e2e on a `transferOwnership` alert — verify the verdict is HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)