### PR TITLE
fix(web3): fail fast on reverts, cap backoff, skip non-public state vars

### DIFF
--- a/tests/test_on_chain_state.py
+++ b/tests/test_on_chain_state.py
@@ -6,12 +6,31 @@ from unittest.mock import MagicMock, patch
 from utils.calldata.decoder import DecodedCall
 from utils.on_chain_state import (
     StateRead,
+    _is_externally_readable,
     _is_simple_type,
     _match_key_value_from_params,
     _parse_var_declaration,
     format_state_reads,
     read_before_state,
 )
+
+
+class TestIsExternallyReadable(unittest.TestCase):
+    def test_public_var(self) -> None:
+        self.assertTrue(_is_externally_readable("uint256 public maxSlippage;"))
+
+    def test_public_mapping(self) -> None:
+        self.assertTrue(_is_externally_readable("mapping(address => uint256) public coverageCap;"))
+
+    def test_internal_var(self) -> None:
+        self.assertFalse(_is_externally_readable("mapping(address => Configuration) internal configuratorParams;"))
+
+    def test_private_var(self) -> None:
+        self.assertFalse(_is_externally_readable("uint256 private _secret;"))
+
+    def test_ignores_natspec_mentioning_public(self) -> None:
+        snippet = "/// @notice exposed via a public helper\nuint256 internal _x;"
+        self.assertFalse(_is_externally_readable(snippet))
 
 
 class TestIsSimpleType(unittest.TestCase):
@@ -184,6 +203,32 @@ class TestReadBeforeState(unittest.TestCase):
     def test_no_source_returns_empty(self, mock_fetch: MagicMock) -> None:
         call = DecodedCall(function_name="setX", signature="setX(uint256)", params=[("uint256", 1)])
         self.assertEqual(read_before_state(1, "0xT", call), [])
+
+    @patch("utils.on_chain_state.ChainManager")
+    @patch("utils.on_chain_state.fetch_source")
+    def test_internal_var_skipped_without_eth_call(self, mock_fetch: MagicMock, mock_chain: MagicMock) -> None:
+        # Compound III Configurator: configuratorParams is `internal`, so there is
+        # no auto-generated getter — the read must be skipped, not attempted.
+        source = """
+        mapping(address => Configuration) internal configuratorParams;
+        function setSupplyKink(address cometProxy, uint64 newSupplyKink) external {
+            configuratorParams[cometProxy].supplyKink = newSupplyKink;
+        }
+        """
+        mock_fetch.return_value = ("Configurator", source)
+        mock_client = MagicMock()
+        mock_chain.get_client.return_value = mock_client
+
+        call = DecodedCall(
+            function_name="setSupplyKink",
+            signature="setSupplyKink(address,uint64)",
+            params=[("address", "0xc3d688B66703497DAA19211EEdff47f25384cdc3"), ("uint64", 850000000000000000)],
+        )
+
+        reads = read_before_state(1, "0x316f9708bb98af7da9c68c1c3b5e79039cd336e3", call)
+
+        self.assertEqual(reads, [])
+        mock_client.eth.call.assert_not_called()
 
     @patch("utils.on_chain_state.fetch_source")
     def test_struct_mapping_returns_empty(self, mock_fetch: MagicMock) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,11 @@ import requests
 from utils.alert import Alert, AlertSeverity, register_alert_hook, send_alert
 from utils.config import Config, ProtocolConfig
 from utils.telegram import TelegramError, send_telegram_message
+from utils.web3_wrapper import (
+    MAX_BACKOFF_SECONDS,
+    ProviderConnectionError,
+    retry_with_provider_rotation,
+)
 
 
 class TestConfig(unittest.TestCase):
@@ -537,6 +542,67 @@ class TestDefiLlama(unittest.TestCase):
                     defillama.fetch_prices(["ethereum:0xtoken"])
             finally:
                 sys.modules.pop("utils.defillama", None)
+
+
+class _FakeProvider:
+    """Minimal stand-in exposing the attributes retry_with_provider_rotation needs."""
+
+    def __init__(self, side_effects):
+        self.provider_urls = ["http://a", "http://b", "http://c", "http://d"]
+        self.max_retries = 3
+        self.backoff_factor = 2
+        self.endpoint_uri = self.provider_urls[0]
+        self._side_effects = list(side_effects)
+        self.call_count = 0
+
+    def _rotate_provider(self):
+        idx = self.provider_urls.index(self.endpoint_uri)
+        self.endpoint_uri = self.provider_urls[(idx + 1) % len(self.provider_urls)]
+
+    @retry_with_provider_rotation
+    def make_request(self):
+        result = self._side_effects[self.call_count]
+        self.call_count += 1
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class TestRetryWithProviderRotation(unittest.TestCase):
+    """Tests for the provider-rotation retry decorator in utils.web3_wrapper."""
+
+    def test_revert_fails_fast_without_retry(self):
+        """Deterministic reverts must raise immediately, not retry across providers."""
+        provider = _FakeProvider([ValueError("execution reverted: 0x")])
+        with patch("utils.web3_wrapper.time.sleep") as mock_sleep:
+            with self.assertRaises(ValueError):
+                provider.make_request()
+        self.assertEqual(provider.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    def test_revert_marker_is_case_insensitive(self):
+        provider = _FakeProvider([RuntimeError("('Execution Reverted', '0x')")])
+        with patch("utils.web3_wrapper.time.sleep"):
+            with self.assertRaises(RuntimeError):
+                provider.make_request()
+        self.assertEqual(provider.call_count, 1)
+
+    def test_transient_error_retries_then_succeeds(self):
+        provider = _FakeProvider([ConnectionError("boom"), ConnectionError("boom"), "ok"])
+        with patch("utils.web3_wrapper.time.sleep"):
+            self.assertEqual(provider.make_request(), "ok")
+        self.assertEqual(provider.call_count, 3)
+
+    def test_backoff_is_capped(self):
+        """Exponential backoff must never exceed MAX_BACKOFF_SECONDS per attempt."""
+        # All 12 attempts (3 retries * 4 providers) fail with a transient error.
+        provider = _FakeProvider([ConnectionError("boom")] * 12)
+        with patch("utils.web3_wrapper.time.sleep") as mock_sleep:
+            with self.assertRaises(ProviderConnectionError):
+                provider.make_request()
+        slept = [call.args[0] for call in mock_sleep.call_args_list]
+        self.assertTrue(slept)
+        self.assertTrue(all(s <= MAX_BACKOFF_SECONDS for s in slept))
 
 
 if __name__ == "__main__":

--- a/utils/on_chain_state.py
+++ b/utils/on_chain_state.py
@@ -103,6 +103,19 @@ def _parse_var_declaration(snippet: str, var_name: str) -> tuple[str, list[str]]
     return None
 
 
+def _is_externally_readable(snippet: str) -> bool:
+    """Whether a state-var declaration exposes a compiler-generated getter.
+
+    Only ``public`` (and ``external``) state variables get an auto-generated
+    getter callable via eth_call. ``internal``/``private`` vars have no getter,
+    so a read always reverts (e.g. Compound's Configurator declares
+    ``mapping(address => Configuration) internal configuratorParams``).
+    """
+    decl_lines = [line for line in snippet.splitlines() if not line.strip().startswith(("///", "*", "/**"))]
+    decl = " ".join(line.strip() for line in decl_lines)
+    return bool(re.search(r"\b(?:public|external)\b", decl))
+
+
 def _match_key_value_from_params(decoded_call: DecodedCall, key_type: str) -> Any | None:
     """Pick the first call param whose type matches the mapping key type.
 
@@ -233,6 +246,12 @@ def read_before_state(
     reads: list[StateRead] = []
     for var_name in var_names:
         snippet = extract_state_var_snippet(source, var_name)
+        if snippet and not _is_externally_readable(snippet):
+            # The var is declared at top level but internal/private, so no
+            # compiler getter exists and a read would always revert. Skip it
+            # rather than guessing a getter from the setter signature.
+            logger.info("Skipping non-public state var %s.%s", target, var_name)
+            continue
         parsed = _parse_var_declaration(snippet, var_name) if snippet else None
 
         key_values: list[Any] = []

--- a/utils/web3_wrapper.py
+++ b/utils/web3_wrapper.py
@@ -21,6 +21,21 @@ logger = get_logger("utils.web3")
 
 T = TypeVar("T")  # Generic type for return values
 
+# Cap on the per-attempt backoff sleep so exponential growth cannot stall a run
+# for hours (a single uncapped attempt could otherwise sleep for over an hour).
+MAX_BACKOFF_SECONDS = 30
+
+# Substrings identifying deterministic contract errors. These return identically
+# from every provider, so retrying or rotating providers is pointless and only
+# wastes time on backoff sleeps.
+NON_RETRYABLE_ERROR_MARKERS = ("execution reverted",)
+
+
+def _is_non_retryable(error: Exception) -> bool:
+    """Return True for deterministic errors that won't change across providers/retries."""
+    msg = str(error).lower()
+    return any(marker in msg for marker in NON_RETRYABLE_ERROR_MARKERS)
+
 
 def retry_with_provider_rotation(func):
     @functools.wraps(func)
@@ -30,10 +45,14 @@ def retry_with_provider_rotation(func):
             try:
                 return func(self, *args, **kwargs)
             except Exception as e:
+                # Deterministic contract errors (e.g. reverts) can never succeed
+                # on retry, so fail fast and let the caller handle it.
+                if _is_non_retryable(e):
+                    raise
                 current_url = self.endpoint_uri
                 errors[current_url] = str(e)
                 logger.warning("Failed on %s: %s", current_url, e)
-                time.sleep(self.backoff_factor * (2**attempt))
+                time.sleep(min(self.backoff_factor * (2**attempt), MAX_BACKOFF_SECONDS))
                 self._rotate_provider()
 
         raise ProviderConnectionError(


### PR DESCRIPTION
## Problem

The hourly monitoring job [hung for 2h40m and was canceled](https://github.com/yearn/monitoring/actions/runs/26495353163/job/78022211287).

**Root cause:** `retry_with_provider_rotation` in `utils/web3_wrapper.py` treated **every** exception as transient — including deterministic `('execution reverted', '0x')` contract errors — and retried across all providers with an **uncapped** exponential backoff (`backoff_factor=2`, so later attempts sleep over an hour each).

### How it triggered
`timelock/timelock_alerts.py` → `ai_explainer` → `on_chain_state` statically scans a setter's source to read "before" state. The timelock op called a setter on a **Compound III `Configurator`** (`0x316f9708…`). Its source assigns to `configuratorParams[cometProxy].…`, so the explainer guessed a getter for `configuratorParams`. But that var is declared `internal` (`mapping(address => Configuration) internal configuratorParams`) — no auto-getter exists — so the call reverts with empty data.

`_call_getter` is meant to swallow that revert instantly, but it was raised one layer down in `make_request`, where the retry decorator rotated all 4 providers with doubling backoff (2, 4, 8 … 4096s), turning a sub-second skip into a multi-hour hang. No single RPC was at fault — every provider returns the same deterministic revert.

## Changes

**1. `utils/web3_wrapper.py` — stop the hang (the actual incident fix)**
- Fail fast: re-raise immediately on non-retryable errors (`execution reverted`).
- Cap per-attempt backoff at `MAX_BACKOFF_SECONDS = 30`.

**2. `utils/on_chain_state.py` — don't attempt doomed reads (follow-up)**
- `read_before_state` now skips state vars that are found at top level but declared `internal`/`private` (no compiler getter exists), instead of guessing a getter from the setter signature. The guess-from-setter fallback is preserved for genuine diamond/struct storage (no declaration found at all).

## Tests
- `tests/test_utils.py::TestRetryWithProviderRotation` — revert fails fast (no retry/sleep), case-insensitive, transient retry-then-succeed, backoff capped.
- `tests/test_on_chain_state.py` — `_is_externally_readable` helper; a Configurator-style `internal configuratorParams` is skipped with **no eth_call**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)