### PR TITLE
feat(alerts): skip governance AI summary, trim multisig output, longer TLDR

### DIFF
--- a/safe/main.py
+++ b/safe/main.py
@@ -222,7 +222,6 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
                 f"🔗 Safe URL: {get_safe_url(safe_address, network_name)}\n"
                 f"#️⃣ Nonce: {nonce}\n"
                 f"📜 Target Contract Address: {target_contract}\n"
-                f"💰 Value: {tx['value']}\n"
                 f"📅 Submission Date: {tx['submissionDate']}"
             )
             # Find the additional info for the current safe address

--- a/tests/test_timelock_alerts.py
+++ b/tests/test_timelock_alerts.py
@@ -112,6 +112,21 @@ class TestBuildAlertMessageTruncation(unittest.TestCase):
         self.assertIn("Short summary.", msg)
         self.assertNotIn("...", msg)
 
+    @patch("timelock.timelock_alerts._get_ai_explanation")
+    def test_ai_skipped_for_governance_protocol(self, mock_ai: object) -> None:
+        """Protocols with dedicated governance monitoring skip the AI summary entirely."""
+        aave_info = TimelockConfig(
+            address="0x" + "bb" * 20,
+            chain_id=1,
+            protocol="AAVE",
+            label="Aave Governance V3",
+        )
+        msg = build_alert_message([_make_event()], aave_info)
+
+        mock_ai.assert_not_called()  # type: ignore[attr-defined]
+        self.assertNotIn("AI Summary", msg)
+        self.assertIn("TIMELOCK: New Operation Scheduled", msg)
+
 
 class TestMapleProposalUnwrap(unittest.TestCase):
     """Maple ProposalScheduled has no target/data; recover them from the source tx."""

--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -72,6 +72,11 @@ TIMELOCK_LIST: list[TimelockConfig] = [
 # Lookup by (lowercase address, chain_id) to support same address on multiple chains
 TIMELOCKS: dict[tuple[str, int], TimelockConfig] = {(t.address, t.chain_id): t for t in TIMELOCK_LIST}
 
+# Protocols whose governance proposals are already monitored (and human-described)
+# by a dedicated script (e.g. aave/proposals.py, compound/proposals.py). For these,
+# the AI summary on the timelock execution is redundant, so we skip it.
+SKIP_AI_SUMMARY_PROTOCOLS: frozenset[str] = frozenset({"AAVE", "COMP", "LIDO", "FLUID"})
+
 _logger = get_logger("timelock_alerts")
 
 
@@ -416,11 +421,13 @@ def build_alert_message(events: list[dict], timelock_info: TimelockConfig) -> st
         # Unknown type - show operationId at minimum
         call_lines.append(f"🆔 Operation: {first.get('operationId') or ''}")
 
-    # AI explanation (best-effort, non-blocking)
+    # AI explanation (best-effort, non-blocking). Skipped for protocols whose
+    # governance proposals are already monitored by a dedicated script.
     ai_line = ""
-    explanation = _get_ai_explanation(events, timelock_info, chain_id)
-    if explanation:
-        ai_line = format_explanation_line(explanation)
+    if timelock_info.protocol.upper() not in SKIP_AI_SUMMARY_PROTOCOLS:
+        explanation = _get_ai_explanation(events, timelock_info, chain_id)
+        if explanation:
+            ai_line = format_explanation_line(explanation)
 
     # Footer (always included)
     if explorer:

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -34,7 +34,8 @@ logger = get_logger("utils.llm.ai_explainer")
 
 SYSTEM_PROMPT = """You are a DeFi risk analyst writing alerts for a monitoring team. Output two sections.
 
-TLDR: 2-4 short sentences. Cover [what changed] · [magnitude or impact] · [risk tag].
+TLDR: up to 10 short sentences. Cover [what changed] · [magnitude or impact] · [risk tag].
+Be as concise as the change allows — use more sentences only when extra detail adds real value.
 Start with a verb describing the effect. Do NOT open with "This transaction", "The proposal",
 or similar — the reader already knows what kind of tx this is.
 End with a risk tag in caps: LOW / MEDIUM / HIGH / CRITICAL.
@@ -77,8 +78,9 @@ Check the draft above against this checklist. Each item is a yes/no question:
 
 1. Does the TLDR start with a verb (NOT "This transaction" / "The proposal" /
    "The transaction" / "This governance")?
-2. Is the TLDR 2-4 short sentences? (Single-sentence TLDRs
-   that omit the impact/magnitude beat are too terse — flag for revision.)
+2. Is the TLDR at most 10 short sentences and does it cover the impact/magnitude
+   beat? (Single-sentence TLDRs that omit impact/magnitude are too terse — flag
+   for revision. TLDRs longer than 10 sentences should be tightened.)
 3. Does the TLDR end with a risk tag in CAPS (LOW / MEDIUM / HIGH / CRITICAL)?
 4. Are all numeric magnitudes/units in the draft supported by either the
    Contract Source Context section or the Current State section above? Or


### PR DESCRIPTION
Three alert-output adjustments.

## 1. Skip AI summary for governance-proposal protocols
Timelock alerts no longer run the AI summary for **AAVE, COMP, LIDO, FLUID**. Their governance proposals are already monitored and human-described by dedicated scripts (`aave/proposals.py`, `compound/proposals.py`, `fluid/proposals.py`, …), so the AI summary on the timelock execution was redundant noise.

Implemented via a `SKIP_AI_SUMMARY_PROTOCOLS` frozenset in `timelock/timelock_alerts.py`; `build_alert_message` checks `timelock_info.protocol` before calling `_get_ai_explanation`. Other timelock protocols (3JANE, MAPLE, etc.) keep their AI summary.

## 2. Trim multisig output
Dropped the `💰 Value:` line from the Safe queued-tx alert (`safe/main.py`).

## 3. Longer AI Summary (TLDR)
The "🤖 AI Summary" (the TLDR shown in Telegram) may now run **up to 10 short sentences** instead of 2-4, so it can carry more context when the change warrants it — while still being told to stay as concise as the change allows. Updated `SYSTEM_PROMPT` and the refine checklist in `utils/llm/ai_explainer.py`.

## Tests
- `tests/test_timelock_alerts.py::...::test_ai_skipped_for_governance_protocol` — an AAVE timelock alert never calls `_get_ai_explanation` and contains no "AI Summary".
- Existing timelock/ai_explainer tests still pass (60 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)