### PR TITLE
fix(morpho): rename Market.uniqueKey to marketId per API change

### DIFF
--- a/morpho/_shared.py
+++ b/morpho/_shared.py
@@ -51,7 +51,7 @@ def get_chain_name(chain: Chain) -> str:
 
 
 def get_market_url(market_id: str, chain: Chain) -> str:
-    """Build the Morpho UI URL for a market by its uniqueKey."""
+    """Build the Morpho UI URL for a market by its marketId."""
     return f"{MORPHO_URL}/{get_chain_name(chain)}/market/{market_id}"
 
 
@@ -66,8 +66,8 @@ def fetch_market_name(market_id: str, chain: Chain) -> str:
     Falls back to the raw market_id on error so alerts always render.
     """
     query = """
-    query GetMarket($uniqueKey: String!, $chainId: Int!) {
-        marketByUniqueKey(uniqueKey: $uniqueKey, chainId: $chainId) {
+    query GetMarket($marketId: String!, $chainId: Int!) {
+        marketById(marketId: $marketId, chainId: $chainId) {
             lltv
             loanAsset { symbol, decimals }
             collateralAsset { symbol }
@@ -78,9 +78,9 @@ def fetch_market_name(market_id: str, chain: Chain) -> str:
         response = request_with_retry(
             "post",
             API_URL,
-            json={"query": query, "variables": {"uniqueKey": market_id, "chainId": chain.chain_id}},
+            json={"query": query, "variables": {"marketId": market_id, "chainId": chain.chain_id}},
         )
-        market = response.json()["data"]["marketByUniqueKey"]
+        market = response.json()["data"]["marketById"]
         collateral_symbol = market["collateralAsset"]["symbol"] if market.get("collateralAsset") else "idle"
         loan_symbol = market["loanAsset"]["symbol"]
         lltv_pct = int(market["lltv"]) / 1e18 * 100
@@ -122,7 +122,7 @@ class BadDebt:
 class MarketMetrics:
     """State + bad debt for a single Morpho Blue market."""
 
-    unique_key: str
+    market_id: str
     loan_asset: Asset
     collateral_asset: Optional[Asset]
     state: MarketState
@@ -144,7 +144,7 @@ def _parse_market_metrics(raw: Dict[str, Any]) -> MarketMetrics:
     bad_debt_raw = raw.get("badDebt") or {}
     loan_asset = _parse_asset(raw.get("loanAsset")) or Asset(address="", symbol="")
     return MarketMetrics(
-        unique_key=raw["uniqueKey"],
+        market_id=raw["marketId"],
         loan_asset=loan_asset,
         collateral_asset=_parse_asset(raw.get("collateralAsset")),
         state=MarketState(
@@ -162,7 +162,7 @@ def _parse_market_metrics(raw: Dict[str, Any]) -> MarketMetrics:
 
 
 def fetch_market_metrics(market_ids: List[str], chain: Chain) -> Dict[str, MarketMetrics]:
-    """Fetch state + bad debt for a batch of market uniqueKeys.
+    """Fetch state + bad debt for a batch of market IDs.
 
     Returns a dict keyed by lowercase market_id mapping to a ``MarketMetrics``
     dataclass. Empty dict on GraphQL error or empty input.
@@ -174,7 +174,7 @@ def fetch_market_metrics(market_ids: List[str], chain: Chain) -> Dict[str, Marke
     query GetMarkets($keys: [String!]!, $chainId: Int!) {
         markets(where: { uniqueKey_in: $keys, chainId_in: [$chainId] }) {
             items {
-                uniqueKey
+                marketId
                 loanAsset { address, symbol, decimals }
                 collateralAsset { address, symbol }
                 state {
@@ -198,4 +198,4 @@ def fetch_market_metrics(market_ids: List[str], chain: Chain) -> Dict[str, Marke
         logger.warning("GraphQL error fetching market metrics: %s", payload["errors"])
         return {}
     items = payload.get("data", {}).get("markets", {}).get("items", []) or []
-    return {item["uniqueKey"].lower(): _parse_market_metrics(item) for item in items}
+    return {item["marketId"].lower(): _parse_market_metrics(item) for item in items}

--- a/morpho/governance.py
+++ b/morpho/governance.py
@@ -153,8 +153,8 @@ def fetch_market_info(market_id: str, chain: Chain) -> tuple[str, int | None]:
     'WBTC/USDC (86.00%)'. On failure returns (market_id, None).
     """
     query = """
-    query GetMarket($uniqueKey: String!, $chainId: Int!) {
-        marketByUniqueKey(uniqueKey: $uniqueKey, chainId: $chainId) {
+    query GetMarket($marketId: String!, $chainId: Int!) {
+        marketById(marketId: $marketId, chainId: $chainId) {
             lltv
             loanAsset { symbol, decimals }
             collateralAsset { symbol }
@@ -165,10 +165,10 @@ def fetch_market_info(market_id: str, chain: Chain) -> tuple[str, int | None]:
         response = request_with_retry(
             "post",
             API_URL,
-            json={"query": query, "variables": {"uniqueKey": market_id, "chainId": chain.chain_id}},
+            json={"query": query, "variables": {"marketId": market_id, "chainId": chain.chain_id}},
         )
         data = response.json()
-        market = data["data"]["marketByUniqueKey"]
+        market = data["data"]["marketById"]
         collateral_symbol = market["collateralAsset"]["symbol"] if market.get("collateralAsset") else "idle"
         loan_asset = market["loanAsset"]
         loan_symbol = loan_asset["symbol"]

--- a/morpho/markets.py
+++ b/morpho/markets.py
@@ -405,7 +405,7 @@ def get_market_url(market: Dict[str, Any]) -> str:
     """Generate URL for a Morpho market."""
     chain_id = market["collateralAsset"]["chain"]["id"]
     chain = Chain.from_chain_id(chain_id)
-    return f"{MORPHO_URL}/{get_chain_name(chain)}/market/{market['uniqueKey']}"
+    return f"{MORPHO_URL}/{get_chain_name(chain)}/market/{market['marketId']}"
 
 
 def get_vault_url(vault_data: Dict[str, Any]) -> str:
@@ -430,11 +430,11 @@ def bad_debt_alert(
         vault_name: Name of the vault (for alert message)
         vault_url: URL of the vault
         chain: Chain the vault is on
-        alerted_markets: Set of market unique keys already alerted (prevents duplicates across vaults)
+        alerted_markets: Set of market IDs already alerted (prevents duplicates across vaults)
     """
     for market in markets:
-        unique_key = market["uniqueKey"]
-        if unique_key in alerted_markets:
+        market_id = market["marketId"]
+        if market_id in alerted_markets:
             continue
 
         bad_debt = market["badDebt"]["usd"]
@@ -446,7 +446,7 @@ def bad_debt_alert(
 
         # Alert if bad debt ratio exceeds threshold
         if bad_debt / borrowed_tvl > BAD_DEBT_RATIO:
-            alerted_markets.add(unique_key)
+            alerted_markets.add(market_id)
             market_url = get_market_url(market)
             market_name = f"{market['collateralAsset']['symbol']}/{market['loanAsset']['symbol']}"
 
@@ -493,21 +493,21 @@ def check_allocation_and_risk(vault_data):
             continue
 
         market = allocation["market"]
-        unique_key = market["uniqueKey"]
+        market_id = market["marketId"]
         market_supply = allocation.get("supplyAssetsUsd", 0) or 0
         if market_supply == 0:
-            logger.info("Skipping market %s has 0 supply assets", unique_key)
+            logger.info("Skipping market %s has 0 supply assets", market_id)
             continue
         allocation_ratio = min(market_supply / total_assets, 1.0)  # prevent allocation ratio from exceeding 100%
 
         # Determine market risk level
-        if unique_key in MARKETS_RISK_1[chain]:
+        if market_id in MARKETS_RISK_1[chain]:
             market_risk_level = 1
-        elif unique_key in MARKETS_RISK_2[chain]:
+        elif market_id in MARKETS_RISK_2[chain]:
             market_risk_level = 2
-        elif unique_key in MARKETS_RISK_3[chain]:
+        elif market_id in MARKETS_RISK_3[chain]:
             market_risk_level = 3
-        elif unique_key in MARKETS_RISK_4[chain]:
+        elif market_id in MARKETS_RISK_4[chain]:
             market_risk_level = 4
         else:
             market_risk_level = 5
@@ -808,7 +808,7 @@ def main() -> None:
                         pendingSupplyCapUsd
                         pendingSupplyCapValidAt
                         market {
-                            uniqueKey
+                            marketId
                             loanAsset {
                                 address
                                 symbol


### PR DESCRIPTION
## Summary
- Morpho's GraphQL API renamed `Market.uniqueKey` → `Market.marketId` and replaced top-level `marketByUniqueKey(uniqueKey, chainId)` with `marketById(marketId, chainId)`. `uv run morpho/markets.py` was failing with HTTP 400: `Cannot query field "uniqueKey" on type "Market"`.
- Updated all GraphQL queries, variable names, response keys, and Python identifiers (`unique_key` → `market_id`, `MarketMetrics.unique_key` → `MarketMetrics.market_id`) across `morpho/markets.py`, `morpho/_shared.py`, `morpho/governance.py`.
- The `MarketFilters.uniqueKey_in` filter input is unchanged on the API and kept as-is.

## Test plan
- [x] `uv run morpho/markets.py` runs end-to-end (no 400, processes all vaults, emits expected risk alerts)
- [x] `morpho._shared.fetch_market_name` returns `"WBTC/USDC (86.00%)"` for a known market on mainnet
- [x] `morpho._shared.fetch_market_metrics` returns a populated `MarketMetrics` with `market_id` set
- [x] `morpho.governance.fetch_market_info` returns `("WBTC/USDC (86.00%)", 6)`
- [x] `uv run ruff format` + `uv run ruff check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)