### PR TITLE
feat(runner): wrap each script's main with crash-alert telemetry

### DIFF
--- a/3jane/main.py
+++ b/3jane/main.py
@@ -451,4 +451,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,13 @@
 - Keep files small and focused on a single task. If a file is too large, split it into smaller files.
 - Ask questions if you are not sure about the code. Ask for clarification if needed before writing the code.
 - always print full addresses with links instead of truncated ones.
+- Every script's `if __name__ == "__main__":` block must wrap its entrypoint with `run_with_alert` from `utils/runner.py` so an unhandled crash sends a Telegram alert and lets the CI loop continue:
+
+  ```python
+  if __name__ == "__main__":
+      from utils.runner import run_with_alert
+
+      run_with_alert(main, PROTOCOL)
+  ```
+
+  For multi-protocol scripts with no single `PROTOCOL` constant, pass a sensible default channel (e.g. `"yearn"` for ops, `"pegs"` for peg monitors).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Shared utilities live in `utils/`:
 | `utils/chains.py` | Chain enum and explorer URLs |
 | `utils/abi.py` | ABI loader |
 | `utils/gauntlet.py` | Gauntlet risk parameter helpers |
+| `utils/runner.py` | `run_with_alert` — script entrypoint wrapper with crash-alert telemetry |
 
 ## Code Style
 
@@ -97,6 +98,26 @@ from utils.telegram import send_telegram_message
 send_telegram_message("Alert text here", PROTOCOL)
 ```
 
+When interpolating uncrafted input (exception messages, API responses, on-chain strings that may contain `_*[\``), pass `plain_text=True` so Telegram doesn't try to parse Markdown on it:
+
+```python
+except requests.RequestException as e:
+    send_telegram_message(f"Fetch failed: {e}", PROTOCOL, disable_notification=True, plain_text=True)
+```
+
+### Script Entrypoint
+
+Wrap each script's entrypoint with `run_with_alert` from `utils/runner.py`. On any unhandled exception it sends a plain-text Telegram crash alert (with the script name and a link to the failing run, when available) and returns normally — so a CI shell loop running multiple scripts continues to the next one instead of aborting the whole run.
+
+```python
+if __name__ == "__main__":
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)
+```
+
+For multi-protocol scripts with no single `PROTOCOL` constant (e.g. `timelock_alerts.py`, `safe/main.py`), pass a sensible default channel as a string: `"yearn"` for general ops, `"pegs"` for peg monitors.
+
 ### Web3 / RPC Calls
 
 Use `ChainManager` for connections and batch requests whenever possible:
@@ -126,7 +147,7 @@ write_last_value_to_file(cache_filename, "MY_KEY", new_value)
 
 ## Adding a New Protocol
 
-1. Create `protocol-name/main.py` following the pattern above
+1. Create `protocol-name/main.py` following the pattern above, with a `main()` function and an `if __name__ == "__main__":` block that wraps it via `run_with_alert(main, PROTOCOL)` (see [Script Entrypoint](#script-entrypoint))
 2. Add a `protocol-name/README.md` describing what it monitors
 3. Add `"protocol-name"` to the `packages` list in `pyproject.toml` under `[tool.setuptools]`
 4. Add the corresponding `TELEGRAM_BOT_TOKEN_*` and `TELEGRAM_CHAT_ID_*` entries to `.env.example`

--- a/aave/main.py
+++ b/aave/main.py
@@ -99,4 +99,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/aave/proposals.py
+++ b/aave/proposals.py
@@ -107,4 +107,6 @@ def handle_governance_proposals():
 
 
 if __name__ == "__main__":
-    handle_governance_proposals()
+    from utils.runner import run_with_alert
+
+    run_with_alert(handle_governance_proposals, PROTOCOL)

--- a/apyusd/main.py
+++ b/apyusd/main.py
@@ -105,4 +105,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/cap/liquidity.py
+++ b/cap/liquidity.py
@@ -103,5 +103,7 @@ def main():
 
 
 if __name__ == "__main__":
+    from utils.runner import run_with_alert
+
     logger.info("Running liquidity checks for CAP protocol")
-    main()
+    run_with_alert(main, PROTOCOL)

--- a/compound/main.py
+++ b/compound/main.py
@@ -54,4 +54,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/compound/proposals.py
+++ b/compound/proposals.py
@@ -143,4 +143,6 @@ def get_proposals():
 
 
 if __name__ == "__main__":
-    get_proposals()
+    from utils.runner import run_with_alert
+
+    run_with_alert(get_proposals, PROTOCOL)

--- a/ethena/ethena.py
+++ b/ethena/ethena.py
@@ -395,6 +395,8 @@ def chaos_labs_check():
 
 
 if __name__ == "__main__":
+    from utils.runner import run_with_alert
+
     # NOTE: skip using LlamaRisk data because it is not reliable
     # llama_risk_check()
-    chaos_labs_check()
+    run_with_alert(chaos_labs_check, PROTOCOL)

--- a/fluid/proposals.py
+++ b/fluid/proposals.py
@@ -134,4 +134,6 @@ def get_proposals():
 
 
 if __name__ == "__main__":
-    get_proposals()
+    from utils.runner import run_with_alert
+
+    run_with_alert(get_proposals, PROTOCOL)

--- a/infinifi/main.py
+++ b/infinifi/main.py
@@ -415,4 +415,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/lido/steth/main.py
+++ b/lido/steth/main.py
@@ -76,4 +76,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/lido/stmatic/main.py
+++ b/lido/stmatic/main.py
@@ -113,4 +113,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/lrt-pegs/curve/main.py
+++ b/lrt-pegs/curve/main.py
@@ -52,4 +52,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    # Multi-pool script with per-pool protocol routing; crash alerts go to the pegs channel.
+    run_with_alert(main, "pegs")

--- a/lrt-pegs/fluid/main.py
+++ b/lrt-pegs/fluid/main.py
@@ -82,4 +82,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/lrt-pegs/origin_protocol.py
+++ b/lrt-pegs/origin_protocol.py
@@ -183,4 +183,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/maker/proposals.py
+++ b/maker/proposals.py
@@ -86,4 +86,6 @@ def get_proposals():
 
 
 if __name__ == "__main__":
-    get_proposals()
+    from utils.runner import run_with_alert
+
+    run_with_alert(get_proposals, PROTOCOL)

--- a/maple/main.py
+++ b/maple/main.py
@@ -340,4 +340,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/morpho/governance.py
+++ b/morpho/governance.py
@@ -360,4 +360,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/morpho/governance_v2.py
+++ b/morpho/governance_v2.py
@@ -409,4 +409,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/morpho/markets.py
+++ b/morpho/markets.py
@@ -891,4 +891,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/morpho/markets_v2.py
+++ b/morpho/markets_v2.py
@@ -457,4 +457,6 @@ def main() -> None:
 # headroom rather than vault-level idle assets.
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/rtoken/monitor_rtoken.py
+++ b/rtoken/monitor_rtoken.py
@@ -236,4 +236,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/safe/main.py
+++ b/safe/main.py
@@ -306,4 +306,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    # Multi-safe script with per-safe routing; crash alerts go to the general ops channel.
+    run_with_alert(main, "yearn")

--- a/stables/main.py
+++ b/stables/main.py
@@ -62,4 +62,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    # Multi-safe script with per-safe routing; crash alerts go to the general ops channel.
+    run_with_alert(main, "yearn")

--- a/strata/main.py
+++ b/strata/main.py
@@ -224,4 +224,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,94 @@
+"""Tests for utils.runner.run_with_alert."""
+
+import unittest
+from unittest.mock import patch
+
+from utils.runner import run_with_alert
+
+
+class TestRunWithAlert(unittest.TestCase):
+    def test_success_runs_entrypoint_no_alert(self) -> None:
+        called = {"n": 0}
+
+        def ok() -> None:
+            called["n"] += 1
+
+        with patch("utils.runner.send_telegram_message") as mock_send:
+            run_with_alert(ok, "yearn")
+        self.assertEqual(called["n"], 1)
+        mock_send.assert_not_called()
+
+    def test_exception_sends_alert_and_returns(self) -> None:
+        def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        with patch("utils.runner.send_telegram_message") as mock_send:
+            # Must NOT raise — the wrapper swallows and alerts
+            run_with_alert(boom, "yearn", name="test.script")
+
+        mock_send.assert_called_once()
+        call_args = mock_send.call_args
+        message = call_args.args[0]
+        self.assertIn("test.script", message)
+        self.assertIn("RuntimeError", message)
+        self.assertIn("kaboom", message)
+        # plain_text=True so Telegram doesn't parse Markdown on the exception string
+        self.assertTrue(call_args.kwargs.get("plain_text"))
+        self.assertTrue(call_args.kwargs.get("disable_notification"))
+        self.assertEqual(call_args.args[1], "yearn")
+
+    def test_alert_includes_github_run_url_when_present(self) -> None:
+        def boom() -> None:
+            raise ValueError("x")
+
+        with (
+            patch("utils.runner.send_telegram_message") as mock_send,
+            patch("utils.runner.get_github_run_url", return_value="https://example.com/run/1"),
+        ):
+            run_with_alert(boom, "yearn", name="s")
+
+        message = mock_send.call_args.args[0]
+        self.assertIn("https://example.com/run/1", message)
+
+    def test_systemexit_propagates(self) -> None:
+        def quit_() -> None:
+            raise SystemExit(2)
+
+        with patch("utils.runner.send_telegram_message") as mock_send:
+            with self.assertRaises(SystemExit):
+                run_with_alert(quit_, "yearn")
+        mock_send.assert_not_called()
+
+    def test_keyboardinterrupt_propagates(self) -> None:
+        def interrupted() -> None:
+            raise KeyboardInterrupt()
+
+        with patch("utils.runner.send_telegram_message") as mock_send:
+            with self.assertRaises(KeyboardInterrupt):
+                run_with_alert(interrupted, "yearn")
+        mock_send.assert_not_called()
+
+    def test_alert_send_failure_does_not_propagate(self) -> None:
+        def boom() -> None:
+            raise RuntimeError("primary")
+
+        def telegram_dies(*args: object, **kwargs: object) -> None:
+            raise ConnectionError("telegram unreachable")
+
+        with patch("utils.runner.send_telegram_message", side_effect=telegram_dies):
+            # Must still return cleanly even when alerting itself fails
+            run_with_alert(boom, "yearn", name="s")
+
+    def test_name_defaults_to_entrypoint_module(self) -> None:
+        def boom() -> None:
+            raise RuntimeError("x")
+
+        with patch("utils.runner.send_telegram_message") as mock_send:
+            run_with_alert(boom, "yearn")
+
+        message = mock_send.call_args.args[0]
+        self.assertIn(boom.__module__, message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -610,4 +610,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    # Multi-protocol script with per-timelock routing; crash alerts go to the general ops channel.
+    run_with_alert(main, "yearn")

--- a/usdai/large_mints.py
+++ b/usdai/large_mints.py
@@ -31,4 +31,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/usdai/main.py
+++ b/usdai/main.py
@@ -216,4 +216,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/ustb/main.py
+++ b/ustb/main.py
@@ -262,4 +262,6 @@ def _to_tokens(raw: int) -> float:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/utils/runner.py
+++ b/utils/runner.py
@@ -1,0 +1,52 @@
+"""Run a script's main function with crash-alert telemetry.
+
+Wrap a script's entrypoint so that any unhandled exception sends a Telegram
+alert and the process still exits 0 — so a CI shell loop running multiple
+monitoring scripts continues to the next one instead of aborting the whole run.
+
+Usage:
+    if __name__ == "__main__":
+        run_with_alert(main, PROTOCOL)
+"""
+
+from typing import Callable
+
+from utils.logging import get_logger
+from utils.telegram import get_github_run_url, send_telegram_message
+
+logger = get_logger("utils.runner")
+
+
+def run_with_alert(entrypoint: Callable[[], None], protocol: str, name: str | None = None) -> None:
+    """Run entrypoint(); on unhandled exception, send a Telegram alert and return.
+
+    KeyboardInterrupt and SystemExit are re-raised so explicit exits aren't
+    swallowed. All other exceptions trigger a plain-text crash alert routed to
+    `protocol`'s Telegram channel, then this function returns normally so a CI
+    shell loop running multiple scripts continues to the next one.
+
+    Args:
+        entrypoint: Zero-arg callable to execute (typically the script's `main`).
+        protocol: Telegram protocol key the crash alert should be routed to.
+        name: Optional display name for the script. Defaults to entrypoint.__module__.
+    """
+    try:
+        entrypoint()
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except Exception as exc:  # noqa: BLE001 - top-level safety net by design
+        script = name or entrypoint.__module__
+        logger.exception("%s crashed", script)
+        lines = [f"🚨 {script} crashed: {type(exc).__name__}: {exc}"]
+        run_url = get_github_run_url()
+        if run_url:
+            lines.append(f"Run: {run_url}")
+        try:
+            send_telegram_message(
+                "\n".join(lines),
+                protocol,
+                disable_notification=True,
+                plain_text=True,
+            )
+        except Exception:  # noqa: BLE001 - alerting must not itself crash the wrapper
+            logger.exception("Failed to send crash alert for %s", script)

--- a/yearn/alert_large_flows.py
+++ b/yearn/alert_large_flows.py
@@ -520,4 +520,6 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/yearn/check_endorsed.py
+++ b/yearn/check_endorsed.py
@@ -162,4 +162,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/yearn/check_shadow_debt.py
+++ b/yearn/check_shadow_debt.py
@@ -506,4 +506,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/yearn/check_stuck_triggers.py
+++ b/yearn/check_stuck_triggers.py
@@ -546,4 +546,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)

--- a/yearn/check_timelock_delay.py
+++ b/yearn/check_timelock_delay.py
@@ -111,4 +111,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from utils.runner import run_with_alert
+
+    run_with_alert(main, PROTOCOL)


### PR DESCRIPTION
## Problem

The hourly workflow runs ~25 scripts in a bash loop. A single script crashing aborts the whole run (bash `set -e`), so every subsequent script is skipped. Worse, the crash itself doesn't surface as an alert — only the GitHub Actions UI shows it.

## Fix

Add `utils/runner.py` with a small wrapper:

```python
def run_with_alert(entrypoint, protocol, name=None):
    try:
        entrypoint()
    except (KeyboardInterrupt, SystemExit):
        raise
    except Exception as exc:
        # log + send plain-text Telegram alert with script name, exception,
        # and run URL — then return normally so the bash loop continues.
```

Each script's `if __name__ == "__main__":` block now calls `run_with_alert(entrypoint, PROTOCOL)`. Net change per script: 3 lines.

### Behavior
- **Unhandled `Exception`** → log it, send a plain-text crash alert (so exception messages with `_*[\` don't break Telegram Markdown parsing) routed to the script's own protocol channel, return exit 0.
- **`KeyboardInterrupt` / `SystemExit`** → re-raised. Explicit exits are not swallowed.
- **Telegram send failure inside the wrapper** → caught and logged. Alerting itself can never crash the wrapper.

### Crash-alert routing
- Standard scripts route to their own `PROTOCOL` constant.
- Multi-protocol scripts (`timelock_alerts.py`, `safe/main.py`, `stables/main.py`) route crash alerts to `"yearn"` (general ops channel).
- `lrt-pegs/curve/main.py` routes to `"pegs"` (matches sibling pegs scripts).

### Workflow
No workflow changes required — scripts now return 0 even on crash, so the existing bash loop in `_run-monitoring.yml` continues to the next script naturally.

## Files

- `utils/runner.py` (new) — the wrapper.
- `tests/test_runner.py` (new) — 7 tests covering success path, exception → alert, `SystemExit`/`KeyboardInterrupt` propagation, alert-send-failure fallback, and run-URL inclusion.
- **34 script files** — `if __name__ == "__main__":` block updated to call `run_with_alert`. All edits follow one of two patterns (standard / multi-protocol).

## Verification

- Full test suite: **364 passed** (7 new + 357 existing, unchanged).
- Ruff format + check clean.
- Smoke imports of representative wrapped scripts succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)