### PR TITLE
fix(timelock): don't advance cache when Telegram send fails

### DIFF
--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -505,6 +505,7 @@ def process_events(events: list[dict], use_cache: bool) -> None:
 
     # Send alerts grouped by protocol, splitting into chunks that fit Telegram's limit
     separator = "\n\n---\n\n"
+    all_sent = True
     for protocol, messages in messages_by_protocol.items():
         chunks: list[str] = []
         current_parts: list[str] = []
@@ -528,10 +529,21 @@ def process_events(events: list[dict], use_cache: bool) -> None:
                 send_telegram_message(chunk, protocol)
             except Exception:
                 _logger.exception("Failed to send Telegram alert for protocol %s", protocol)
+                all_sent = False
 
+    # Only advance the cache when every chunk landed. Advancing on partial
+    # failure silently drops the failed events — the next run sees no new
+    # events past the new timestamp and the alerts are lost forever. Risk of
+    # duplicate alerts on retry is acceptable; missing alerts is not.
     if use_cache and max_timestamp > 0:
-        write_last_value_to_file(cache_filename, CACHE_KEY, str(max_timestamp))
-        _logger.info("Updated cache: %s = %s", CACHE_KEY, max_timestamp)
+        if all_sent:
+            write_last_value_to_file(cache_filename, CACHE_KEY, str(max_timestamp))
+            _logger.info("Updated cache: %s = %s", CACHE_KEY, max_timestamp)
+        else:
+            _logger.warning(
+                "Skipping cache update due to Telegram send failure(s); %s events will be re-fetched on the next run",
+                len(events),
+            )
 
 
 def main() -> None:

--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -20,7 +20,7 @@ from utils.llm.ai_explainer import explain_batch_transaction, explain_transactio
 from utils.logging import get_logger
 from utils.proxy import build_diff_url, detect_proxy_upgrade, get_current_implementation
 from utils.safe_tx import unwrap_safe_exec_transaction
-from utils.telegram import MAX_MESSAGE_LENGTH, send_telegram_message
+from utils.telegram import MAX_MESSAGE_LENGTH, escape_markdown, send_telegram_message
 from utils.web3_wrapper import ChainManager
 
 load_dotenv()
@@ -377,11 +377,14 @@ def build_alert_message(events: list[dict], timelock_info: TimelockConfig) -> st
     tx_hash = first["transactionHash"]
     timelock_type = first.get("timelockType", "Unknown")
 
-    # Header (always included)
+    # Header (always included). Escape protocol and label since they're
+    # config-supplied and may contain Markdown-V1 specials — e.g. the
+    # underscore in "YEARN_TIMELOCK" was opening an italic that never
+    # closed, breaking the whole message with Telegram 400.
     header_lines: list[str] = [
         "⏰ *TIMELOCK: New Operation Scheduled*",
-        f"🅿️ Protocol: {timelock_info.protocol}",
-        _format_address(first["timelockAddress"], explorer, f"📋 {timelock_info.label}: "),
+        f"🅿️ Protocol: {escape_markdown(timelock_info.protocol)}",
+        _format_address(first["timelockAddress"], explorer, f"📋 {escape_markdown(timelock_info.label)}: "),
         f"🔗 Chain: {chain_name}",
     ]
 

--- a/timelock/timelock_alerts.py
+++ b/timelock/timelock_alerts.py
@@ -466,10 +466,15 @@ def process_events(events: list[dict], use_cache: bool) -> None:
     # Group events: only TimelockController has batch operations (multiple
     # CallScheduled events sharing the same operationId). All other types
     # emit one event per operation, so each is its own group.
+    # Key includes chainId because operationId is content-derived
+    # (keccak of targets/values/data/predecessor/salt) — when the same
+    # address (e.g. Yearn TimelockController) lives on multiple chains, an
+    # identical payload scheduled on two of them collides on operationId
+    # and only the first chain's alert would fire.
     operations: dict[str, list[dict]] = {}
     for event in events:
         if event.get("timelockType") == "TimelockController":
-            key = event["operationId"]
+            key = f"{event['chainId']}:{event['operationId']}"
         else:
             key = event["id"]
         if key not in operations:

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import requests
 from dotenv import load_dotenv
@@ -11,6 +12,17 @@ logger = get_logger("utils.telegram")
 
 # Maximum message length allowed by Telegram API
 MAX_MESSAGE_LENGTH = 4096
+
+# Matches `bot<digits>:<token>` in Telegram API URLs. Used to scrub the bot
+# token out of exception messages — `requests.HTTPError.__str__()` includes
+# the full URL, so without this the token leaks into any log or alert that
+# surfaces the error. GitHub Actions auto-masks secrets in workflow logs,
+# but local runs and any Telegram crash-alert do not.
+_BOT_TOKEN_RE = re.compile(r"bot\d+:[A-Za-z0-9_-]+")
+
+
+def _redact_bot_token(text: str) -> str:
+    return _BOT_TOKEN_RE.sub("bot***", text)
 
 
 def escape_markdown(text: str) -> str:
@@ -100,10 +112,12 @@ def send_telegram_message(
                 body = f" body={err_response.text}"
             except Exception:
                 pass
-        raise TelegramError(f"Failed to send telegram message: {e}{body}")
+        raise TelegramError(_redact_bot_token(f"Failed to send telegram message: {e}{body}"))
 
     if response.status_code != 200:
-        raise TelegramError(f"Failed to send telegram message: {response.status_code} - {response.text}")
+        raise TelegramError(
+            _redact_bot_token(f"Failed to send telegram message: {response.status_code} - {response.text}")
+        )
 
 
 def get_github_run_url() -> str:

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -90,7 +90,17 @@ def send_telegram_message(
         response = requests.post(url, json=payload, timeout=10)
         response.raise_for_status()
     except requests.RequestException as e:
-        raise TelegramError(f"Failed to send telegram message: {e}")
+        # Telegram's response body carries the real failure reason
+        # (e.g. "can't parse entities", invalid message_thread_id). Surface it
+        # so callers don't have to debug from just an HTTP status.
+        body = ""
+        err_response = getattr(e, "response", None)
+        if err_response is not None:
+            try:
+                body = f" body={err_response.text}"
+            except Exception:
+                pass
+        raise TelegramError(f"Failed to send telegram message: {e}{body}")
 
     if response.status_code != 200:
         raise TelegramError(f"Failed to send telegram message: {response.status_code} - {response.text}")


### PR DESCRIPTION
## Summary
- Skip `TIMELOCK_LAST_TS` update on any Telegram chunk failure so failed events get re-fetched and retried, instead of being silently lost.
- Include Telegram's response body (the JSON `description`) in `TelegramError` so the next 400 is debuggable from the log alone.
- Key TimelockController operation grouping by `(chainId, operationId)` so cross-chain identical payloads don't collide into a single alert.
- Escape `timelock_info.protocol` and `timelock_info.label` in `build_alert_message`. The `_` in `YEARN_TIMELOCK` was opening a Markdown V1 italic that never closed — Telegram's parser then failed on the first downstream code-span backtick with `can't parse entities: Can't find end of the entity starting at byte offset 807`. This is the root cause of the 09:39 UTC 400.
- Scrub the bot token from every `TelegramError` message. `requests.HTTPError.__str__()` puts the full URL (including `bot<TOKEN>`) into the exception string; the previous code re-raised that into `TelegramError` and into crash alerts. GH Actions masks secrets in workflow logs, but local runs and the new error-body path do not.

## Timeline of the outage
1. **2026-05-27 18:07 UTC → 2026-05-28 09:02 UTC** — Morpho's `Market.uniqueKey` → `marketId` API rename made `morpho/markets.py` exit non-zero. `bash -eo pipefail` aborted the hourly loop before `timelock_alerts.py` ran.
2. **2026-05-28 09:39 UTC** — first run after the Morpho fix landed. 6 backlogged TimelockEvent rows, 4 ops. The YEARN_TIMELOCK chunk was sent to Telegram and returned 400. The script logged the error, **and still advanced `TIMELOCK_LAST_TS=1779958199`**, dropping the failed alerts from the cache window forever.
3. **2026-05-28 ~18:11 UTC** — local repro (this PR's diagnostic): re-ran with `--no-cache --since-seconds 172800 --protocol YEARN_TIMELOCK`. Same 400. Captured response body: `{"ok":false,"error_code":400,"description":"Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 807"}`. Byte 807 was the closing backtick before the AI summary; the unclosed italic was the `_` in `YEARN_TIMELOCK` at byte 63.
4. **Recovery** — sent the two missed alerts manually with the underscore escaped. Mainnet `0x5dac358a…` (msg 1562) and Base `0xe8c04f74…` (msg 1563) both landed (status 200) in the YEARN_TIMELOCK channel.

## Why each change
- **Cache-on-failure.** Even after this PR fixes the escape, the script will still drop events any time Telegram returns 400 for any reason (rate limit, future label with markdown special, content rejected by a new server-side rule). Tracking `all_sent` and skipping the cache write when anything failed makes the retry loop the system's recovery — at the cost of duplicate alerts for successful protocols on the next run after a partial failure. Worth it.
- **Error body in `TelegramError`.** Without this, the original 09:39 UTC log line was only `400 Client Error for url: …` — useless for diagnosis. With this, the description field (`can't parse entities: …`) reaches the log.
- **`(chainId, operationId)` key.** `operationId` is `keccak(targets, values, datas, predecessor, salt)` — no contract address. The Yearn timelock has the same address on every chain we monitor; a cross-chain identical payload would collide, the grouper would merge events from different chains into one bucket, and only the first chain's alert would fire. Hasn't bitten production yet but was waiting.
- **`escape_markdown` for protocol/label.** Direct fix for the underlying 400. Both fields are config-supplied; future additions with any of `_ * \` [` in them would silently break alerts the same way otherwise.
- **Token redaction.** During this debugging cycle the bot token leaked into a Claude conversation context via an unredacted exception string. **`TELEGRAM_BOT_TOKEN_DEFAULT` should be rotated** independently of this PR; the redaction prevents future leaks.

## Still TODO (not in this PR)
1. **AI summary text.** `format_explanation_line`'s output is interpolated into the Markdown message unescaped. The LLM happens to not have emitted `_`/`*` in the texts I observed, but it could. Either escape on the way out or switch the AI lines to plain code blocks.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format .` clean
- [x] `uv run pytest tests/` — 407 passed, 4 skipped (pre-existing)
- [x] Local diagnostic: posted the failing Mainnet payload unescaped → 400 with `can't parse entities` body; posted the same payload with `_` escaped → 200, message landed in the channel.
- [x] Both missed 2026-05-27 alerts (Mainnet + Base) delivered to YEARN_TIMELOCK manually after fix confirmed.
- [ ] Next hourly CI run after merge: confirm new events alert cleanly end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)