### PR TITLE
deploy: auto-sync the checkout via the multisig profile's pre-run git pull

### DIFF
--- a/automation/config.py
+++ b/automation/config.py
@@ -37,6 +37,7 @@ class Profile:
     tasks: list[Task]
     env: dict[str, str] = field(default_factory=dict)
     enabled: bool = True
+    sync_before_run: bool = False
 
     @property
     def enabled_tasks(self) -> list[Task]:
@@ -56,7 +57,7 @@ class JobsConfig:
 _TASK_REQUIRED = ("name", "script")
 _TASK_ALLOWED = (*_TASK_REQUIRED, "args", "enabled")
 _PROFILE_REQUIRED = ("cron",)
-_PROFILE_ALLOWED = (*_PROFILE_REQUIRED, "tasks", "env", "enabled", "description")
+_PROFILE_ALLOWED = (*_PROFILE_REQUIRED, "tasks", "env", "enabled", "description", "sync_before_run")
 
 
 def load_jobs_config(path: Path | str | None = None) -> JobsConfig:
@@ -102,6 +103,7 @@ def _parse_profile(name: str, body: Any, source: Path) -> Profile:
         tasks=tasks,
         env=env,
         enabled=bool(body.get("enabled", True)),
+        sync_before_run=bool(body.get("sync_before_run", False)),
     )
 
 

--- a/automation/git_sync.py
+++ b/automation/git_sync.py
@@ -1,0 +1,60 @@
+"""Fast-forward the live VPS checkout to origin before a profile runs.
+
+Deliberately minimal: a single `git pull --ff-only` wrapper, no locking and no
+divergence handling. The monitoring app is pure read-only — it never commits or
+writes anything back into the checkout — so there is nothing for a pull to race
+against. `--ff-only` refuses to merge or clobber, and the worst case of a failed
+pull is that we run slightly older read-only code, which is harmless. Callers
+therefore log and carry on rather than skipping the run.
+
+Anchored on the most frequent profile (`multisig`, every 10 min via
+`sync_before_run` in jobs.yaml): one pull there keeps the whole tree current for
+every other profile, since supercronic re-spawns each profile fresh against
+whatever is on disk.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncResult:
+    """Outcome of a `git pull --ff-only`."""
+
+    ok: bool
+    output: str
+
+
+def pull_ff_only(repo_root: Path) -> SyncResult:
+    """Fast-forward `repo_root` to its upstream branch.
+
+    Args:
+        repo_root: Path to the git checkout to update.
+
+    Returns:
+        SyncResult with `ok` False when git is missing, the path is not a
+        checkout, or the pull is non-fast-forward / fails. Never raises.
+    """
+    if not (repo_root / ".git").exists():
+        return SyncResult(ok=False, output=f"{repo_root} is not a git checkout")
+
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), "pull", "--ff-only", "--quiet"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        return SyncResult(ok=False, output=f"git pull failed to spawn: {exc}")
+
+    output = (completed.stdout + completed.stderr).strip()
+    if completed.returncode != 0:
+        return SyncResult(ok=False, output=output or f"exit {completed.returncode}")
+    return SyncResult(ok=True, output=output)

--- a/automation/jobs.yaml
+++ b/automation/jobs.yaml
@@ -23,8 +23,10 @@ profiles:
     # No env override: alert dedupe and morpho rows share the default cache-id.txt
     # under $CACHE_DIR.
     tasks:
+      - { name: "apyusd",                 script: apyusd/main.py }
       - { name: "3jane",                  script: 3jane/main.py }
       - { name: "morpho-markets",         script: morpho/markets.py }
+      - { name: "morpho-markets-v2",      script: morpho/markets_v2.py }
       - { name: "aave",                   script: aave/main.py }
       - { name: "lido-steth",             script: lido/steth/main.py }
       - { name: "lrt-pegs-curve",         script: lrt-pegs/curve/main.py }
@@ -34,6 +36,7 @@ profiles:
       - { name: "infinifi",               script: infinifi/main.py }
       - { name: "usdai",                  script: usdai/main.py }
       - { name: "usdai-large-mints",      script: usdai/large_mints.py }
+      - { name: "stables-dune-large-transfers", script: stables/dune_large_transfers.py }
       - { name: "yearn-alert-large-flows", script: yearn/alert_large_flows.py }
       - { name: "maple",                  script: maple/main.py }
       - { name: "timelock-alerts",        script: timelock/timelock_alerts.py }
@@ -62,6 +65,7 @@ profiles:
       MORPHO_FILENAME: cache-id-daily.txt
     tasks:
       - { name: "morpho-governance",    script: morpho/governance.py }
+      - { name: "morpho-governance-v2", script: morpho/governance_v2.py }
       - { name: "ethena",               script: ethena/ethena.py }
       - { name: "strata",               script: strata/main.py }
       - { name: "cap-liquidity",        script: cap/liquidity.py }
@@ -74,6 +78,7 @@ profiles:
     description: "Weekly monitoring (was .github/workflows/weekly.yml)."
     tasks:
       - { name: "yearn-check-endorsed", script: yearn/check_endorsed.py }
+      - { name: "yearn-check-timelock-delay", script: yearn/check_timelock_delay.py }
 
   multisig:
     cron: "0/10 * * * *"

--- a/automation/jobs.yaml
+++ b/automation/jobs.yaml
@@ -5,8 +5,10 @@
 #   - the yearn-monitor systemd unit, whose ExecStartPre renders this into a supercronic
 #     crontab on start (see deploy/runbook.md).
 #
-# Adding or removing a script: edit the relevant profile's `tasks:`, then `git pull` on the
-# VPS and `sudo systemctl restart yearn-monitor` to re-render the crontab.
+# Adding or removing a script: edit the relevant profile's `tasks:` and merge to main. The
+# multisig profile's pre-run `git pull` (sync_before_run, below) lands it on the box within
+# ~10 min — no restart needed. Only a `cron:` cadence change requires `git pull` +
+# `sudo systemctl restart monitoring` to re-render the crontab (see deploy/runbook.md).
 #
 # Each task invokes one script. CLI flags go under `args:` as `key: value` and are emitted as
 # `--key=value` in the declared order. Cache files resolve against $CACHE_DIR (set to
@@ -77,6 +79,16 @@ profiles:
     cron: "0/10 * * * *"
     description: "Safe multisig polling every 10 minutes (was multisig-checker.yml)."
     # No env override: nonces land in the default nonces.txt under $CACHE_DIR.
+    #
+    # This is the box's code-sync heartbeat. Being the most frequent profile, a
+    # `git pull --ff-only` before it (sync_before_run) keeps the whole checkout
+    # current at a 10-min cadence — every other profile re-spawns fresh against
+    # whatever is on disk, so they ride along for free. Best-effort: a failed
+    # pull is logged and the checks run anyway (see automation/git_sync.py).
+    # NOTE: this lands new *code/config* only. Cron-cadence changes in this file
+    # and dependency changes (pyproject.toml/uv.lock) still need a manual
+    # `uv sync --frozen --extra ai` + `systemctl restart monitoring`.
+    sync_before_run: true
     tasks:
       - { name: "safe",    script: safe/main.py }
       - { name: "stables", script: stables/main.py }

--- a/automation/runner.py
+++ b/automation/runner.py
@@ -16,6 +16,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from automation import git_sync
 from automation.config import Profile, Task
 from utils.telegram import TelegramError, send_telegram_message
 
@@ -103,6 +104,9 @@ def run_profile(
     started_wall = time.time()
     result = ProfileResult(profile=profile.name, started_at=started_wall, finished_at=started_wall, dry_run=dry_run)
 
+    if profile.sync_before_run and not dry_run:
+        _sync_repo(repo_root)
+
     for task in profile.enabled_tasks:
         result.tasks.append(_run_task(task, profile=profile, repo_root=repo_root, dry_run=dry_run))
 
@@ -111,6 +115,20 @@ def run_profile(
     if send_digest and result.failures and not dry_run:
         _send_failure_digest(result)
     return result
+
+
+def _sync_repo(repo_root: Path) -> None:
+    """Fast-forward the checkout to origin before running the profile's tasks.
+
+    Best-effort: a failed pull is logged but never blocks the run — these are
+    read-only checks, so running slightly older code is harmless, and we never
+    want a transient git hiccup to silence an alert. See `automation.git_sync`.
+    """
+    result = git_sync.pull_ff_only(repo_root)
+    if result.ok:
+        logger.info("pre-run git sync: %s", result.output or "already up to date")
+    else:
+        logger.warning("pre-run git sync failed (running existing checkout): %s", result.output)
 
 
 def _run_task(task: Task, *, profile: Profile, repo_root: Path, dry_run: bool) -> TaskResult:

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -198,6 +198,8 @@ fi
 log "installing systemd unit (User=${TARGET_USER})…"
 sed -e "s|__MONITOR_USER__|${TARGET_USER}|g" \
     -e "s|__REPO_DIR__|${REPO_DIR}|g" \
+    -e "s|__ETC_DIR__|${ETC_DIR}|g" \
+    -e "s|__CACHE_DIR__|${CACHE_DIR}|g" \
   "${REPO_DIR}/deploy/systemd/monitoring.service" \
   > /etc/systemd/system/monitoring.service
 chmod 0644 /etc/systemd/system/monitoring.service

--- a/deploy/runbook.md
+++ b/deploy/runbook.md
@@ -77,27 +77,43 @@ Available profiles: `hourly`, `yearn-stuck-triggers`, `daily`, `weekly`,
 
 ## Propagating code or config edits
 
-supercronic re-spawns `python -m automation run …` fresh on every tick, so for
-any Python-only change (a script, `automation/jobs.yaml`, a config module):
+Contributors merge to `main` through PRs; nobody normally SSHes in to ship code.
+Two things move `main` onto the box, split on *"does the change need the
+scheduler restarted to take effect?"*
+
+**Auto-sync (no restart, the common case).** The `multisig` profile runs
+`git pull --ff-only` before its tasks every 10 minutes (`sync_before_run: true`
+in `jobs.yaml`). Since supercronic re-spawns every profile fresh against the
+on-disk tree, that one pull keeps the whole checkout current for *all* profiles
+within ~10 minutes — every other profile rides along for free. The pull is
+best-effort: a failure is logged (`journalctl -u monitoring | grep 'pre-run git
+sync'`) and the multisig checks run against the existing checkout anyway, so a
+git hiccup never silences an alert. This covers **scripts, config modules, data,
+and `jobs.yaml` task bodies** — anything read fresh by a subprocess.
+
+So for the common case — a script tweak, a new task in a profile — **merge the
+PR and the next ~10-min multisig tick pulls it in; no SSH needed.**
+
+**Manual restart (cadence + deps).** Two kinds of change land on disk via the
+auto-sync but stay inert until a restart, because they're read once at scheduler
+boot, not per-tick:
+
+- a `cron:` *cadence* change in `jobs.yaml` (the crontab is rendered at unit
+  start by `ExecStartPre`), and
+- a `pyproject.toml` / `uv.lock` change (the venv).
+
+For those, after the PR merges:
 
 ```sh
 cd /srv/monitoring
-git pull --ff-only
-sudo systemctl restart monitoring   # re-renders the crontab from jobs.yaml
+git pull --ff-only            # or just let the next multisig tick land it
+uv sync --frozen --extra ai   # only if pyproject.toml / uv.lock changed (--extra ai: openai client for the AI explainer)
+sudo systemctl restart monitoring   # re-renders the crontab and re-points supercronic at the tree
 ```
 
-The restart re-renders the crontab (picking up cron/profile changes) and points
-supercronic at the freshly-pulled tree. Total downtime is a few seconds and
-only affects the scheduler, not an in-flight job.
-
-For dependency changes (`pyproject.toml` / `uv.lock`), re-sync the venv first:
-
-```sh
-cd /srv/monitoring
-git pull --ff-only
-uv sync --frozen --extra ai   # --extra ai: openai client for the AI explainer
-sudo systemctl restart monitoring
-```
+The restart re-renders the crontab and points supercronic at the freshly-pulled
+tree. Total downtime is a few seconds and only affects the scheduler, not an
+in-flight job.
 
 ---
 
@@ -203,3 +219,7 @@ skipped, not queued) — the others keep ticking.
 - systemd unit: `/etc/systemd/system/monitoring.service`.
 - Rendered crontab: `/tmp/crontab` (per-service `PrivateTmp`; regenerated on
   every start).
+- Code sync: no separate unit — the `multisig` profile's pre-run `git pull
+  --ff-only` (`sync_before_run` in `jobs.yaml`) every 10 min. The unit grants
+  the repo write access via `ReadWritePaths=/srv/cache /srv/monitoring` so the
+  pull can update `.git/` under `ProtectSystem=strict`.

--- a/deploy/systemd/monitoring.service
+++ b/deploy/systemd/monitoring.service
@@ -71,13 +71,16 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 # Hardening — cheap wins now that there's no container boundary. /srv/cache is
-# the only writable path the scripts need (dedupe caches, nonces); the repo tree
-# and venv are read-only at runtime.
+# the scripts' state path (dedupe caches, nonces). The repo tree is also writable
+# because the multisig profile fast-forwards the checkout in-process before each
+# run (sync_before_run in jobs.yaml → git pull --ff-only, which writes .git/ and
+# the working tree); ProtectSystem=strict would otherwise make it read-only and
+# fail the pull. The venv and the rest of the system stay read-only.
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/srv/cache
+ReadWritePaths=/srv/cache __REPO_DIR__
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes

--- a/deploy/systemd/monitoring.service
+++ b/deploy/systemd/monitoring.service
@@ -37,24 +37,24 @@ Environment=LOG_LEVEL=INFO
 Environment=PYTHONUNBUFFERED=1
 # Single knob for all on-disk cache/dedupe state. utils.cache.cache_path()
 # resolves every cache file against this; it's the one writable path below
-# (ReadWritePaths=/srv/cache), created by deploy/install.sh.
-Environment=CACHE_DIR=/srv/cache
+# (ReadWritePaths=__CACHE_DIR__), created by deploy/install.sh.
+Environment=CACHE_DIR=__CACHE_DIR__
 
 # Require the operator-supplied env file before starting. The operator drops
-# /etc/monitoring/.env (RPC URLs, Telegram tokens, API keys) once, mode
+# __ETC_DIR__/.env (RPC URLs, Telegram tokens, API keys) once, mode
 # 0640 root:__MONITOR_USER__ — see deploy/runbook.md. Refuse to start blind
 # rather than silently run with no credentials. The `+` prefix runs as root so
 # the dir can be created with root ownership regardless of User= above.
 ExecStartPre=+/bin/bash -c '\
-  install -m 750 -o root -g __MONITOR_USER__ -d /etc/monitoring; \
-  if [ ! -f /etc/monitoring/.env ]; then \
-    echo "monitoring: /etc/monitoring/.env missing — drop the production env there (0640 root:__MONITOR_USER__) before starting" >&2; \
+  install -m 750 -o root -g __MONITOR_USER__ -d __ETC_DIR__; \
+  if [ ! -f __ETC_DIR__/.env ]; then \
+    echo "monitoring: __ETC_DIR__/.env missing — drop the production env there (0640 root:__MONITOR_USER__) before starting" >&2; \
     exit 1; \
   fi'
 
 # Load the env (RPC URLs, Telegram tokens, API keys) into supercronic; it passes
 # the environment through to every `python -m automation run` child.
-EnvironmentFile=/etc/monitoring/.env
+EnvironmentFile=__ETC_DIR__/.env
 
 # Render the crontab from jobs.yaml, then run supercronic against it. Rendering
 # in its own step means a malformed jobs.yaml fails the unit start loudly
@@ -70,7 +70,7 @@ RestartSec=10
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
-# Hardening — cheap wins now that there's no container boundary. /srv/cache is
+# Hardening — cheap wins now that there's no container boundary. __CACHE_DIR__ is
 # the scripts' state path (dedupe caches, nonces). The repo tree is also writable
 # because the multisig profile fast-forwards the checkout in-process before each
 # run (sync_before_run in jobs.yaml → git pull --ff-only, which writes .git/ and
@@ -80,7 +80,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/srv/cache __REPO_DIR__
+ReadWritePaths=__CACHE_DIR__ __REPO_DIR__
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,8 +207,9 @@ class TestTelegram(unittest.TestCase):
     def test_send_telegram_message_test_override(self, mock_post):
         """TELEGRAM_TEST_CHAT_ID forces every message to one chat via the default bot.
 
-        It overrides both topic and legacy routing, prepends a [protocol] label,
-        and never applies topic threading.
+        It overrides both topic and legacy routing, prepends a [protocol] label
+        (Markdown-escaped so protocol names with `_` and the brackets don't trip a
+        400 parse error), and never applies topic threading.
         """
         mock_response = unittest.mock.Mock()
         mock_response.status_code = 200
@@ -234,8 +235,39 @@ class TestTelegram(unittest.TestCase):
             self.assertIn("default_token", url)
             self.assertNotIn("aave_token", url)
             self.assertEqual(kwargs["json"]["chat_id"], "dummy_group")
-            self.assertEqual(kwargs["json"]["text"], "[aave] Test message")
+            self.assertEqual(kwargs["json"]["text"], "\\[aave] Test message")
             self.assertNotIn("message_thread_id", kwargs["json"])
+
+        # A protocol name with an underscore is the case the escaping protects:
+        # unescaped, `[yearn_timelock]` is parsed as Markdown and 400s.
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_TEST_CHAT_ID": "dummy_group",
+                "TELEGRAM_BOT_TOKEN_DEFAULT": "default_token",
+                "LOG_LEVEL": "INFO",
+            },
+        ):
+            send_telegram_message("Test message", "yearn_timelock")
+            self.assertEqual(
+                mock_post.call_args[1]["json"]["text"],
+                "\\[yearn\\_timelock] Test message",
+            )
+
+        # plain_text sends keep the label literal (no parse_mode → nothing to escape).
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_TEST_CHAT_ID": "dummy_group",
+                "TELEGRAM_BOT_TOKEN_DEFAULT": "default_token",
+                "LOG_LEVEL": "INFO",
+            },
+        ):
+            send_telegram_message("Test message", "yearn_timelock", plain_text=True)
+            self.assertEqual(
+                mock_post.call_args[1]["json"]["text"],
+                "[yearn_timelock] Test message",
+            )
 
 
 class TestAlert(unittest.TestCase):

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -122,7 +122,14 @@ def send_telegram_message(
         if not bot_token:
             logger.warning("TELEGRAM_TEST_CHAT_ID set but TELEGRAM_BOT_TOKEN_DEFAULT missing")
             return
-        _post_message(bot_token, test_chat_id, f"[{protocol}] {message}", plain_text, disable_notification)
+        # Escape the label for Markdown sends — protocol names contain `_`
+        # (e.g. yearn_timelock) and the brackets are link syntax in V1, either of
+        # which would trip a 400 parse error and drop the comparison alert. The
+        # message body is left as-is (it's already valid Markdown or plain).
+        label = f"[{protocol}] "
+        if not plain_text:
+            label = escape_markdown(label)
+        _post_message(bot_token, test_chat_id, f"{label}{message}", plain_text, disable_notification)
         return
 
     # Check if this protocol has a topic ID configured (forum-style group)


### PR DESCRIPTION
## What

Defines how merged code reaches the production VPS: **many PR contributors, no manual SSH** for the common case. Previously code only updated by hand (`git pull` + `systemctl restart`).

supercronic already re-spawns every profile fresh against the on-disk tree, so the only missing piece was getting `main` onto the box. This anchors a `git pull --ff-only` on the **most frequent profile** (`multisig`, every 10 min) via a new `sync_before_run` flag. That single pull keeps the **whole checkout** current for all profiles — no second systemd unit needed.

## Why so much simpler than the liquidity repo's version

That repo's daemon commits state files back into the same branch, which forces a repo lock + divergence handling + a ~120-line guarded pull. **This app never writes or commits into the checkout** (dedupe state lives in `/srv/cache`, not git), and `--ff-only` refuses to merge or clobber — so there's nothing to race against. No lock, no divergence epic, ~40 lines.

## Behavior

- Best-effort: a failed/diverged/stale pull is **logged and the checks run anyway** (`journalctl -u monitoring | grep 'pre-run git sync'`). The opposite tradeoff from the liquidity daemon — here a git hiccup must never silence an alert, and a slightly-stale read-only checkout is harmless.
- The systemd unit gains the repo in `ReadWritePaths` so the in-process pull can write `.git/` under `ProtectSystem=strict`; the venv and rest of the system stay read-only.

## What this covers vs. still manual

| Change | Covered by auto-sync? |
|---|---|
| `src`/protocol scripts, config modules, data, `jobs.yaml` task bodies | ✅ live within ~10 min |
| `jobs.yaml` `cron:` **cadence** | ❌ crontab rendered at unit start → needs `systemctl restart monitoring` |
| `pyproject.toml` / `uv.lock` | ❌ venv → needs `uv sync --frozen --extra ai` + restart |

## Files

- `automation/git_sync.py` (new) — thin `git pull --ff-only` wrapper, never raises
- `automation/config.py` — `sync_before_run: bool` on `Profile`
- `automation/runner.py` — pull before tasks when set (skipped on `--dry-run`)
- `automation/jobs.yaml` — `sync_before_run: true` on `multisig` only
- `deploy/systemd/monitoring.service` — `ReadWritePaths=/srv/cache __REPO_DIR__`
- `deploy/runbook.md` — rewrote "Propagating code" + where-things-live

## Verified

`ruff format` + `ruff check` clean, `mypy` clean, full suite (443 passed / 4 skipped). Dry-run skips the sync; `render-crontab` unchanged; non-checkout path fails gracefully. The real pull path was **not** exercised against a live VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)