### PR TITLE
Fix Safe nonce dedupe and Telegram plain text sends

### DIFF
--- a/safe/main.py
+++ b/safe/main.py
@@ -126,7 +126,10 @@ def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]
 
     baseline = last_cached_nonce
     if current_safe_nonce is not None:
-        baseline = max(baseline, current_safe_nonce - 1)
+        chain_baseline = current_safe_nonce - 1
+        if chain_baseline > last_cached_nonce:
+            write_last_executed_nonce_to_file(safe_address, chain_baseline)
+        baseline = max(baseline, chain_baseline)
 
     return [tx for tx in pending_txs if int(tx["nonce"]) > baseline]
 

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -1,0 +1,39 @@
+import importlib
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestSafePendingTransactions(unittest.TestCase):
+    def _import_safe_main(self):
+        with patch.dict(os.environ, {"SAFE_API_KEY": "test-key"}):
+            import safe.main as safe_main
+
+            return importlib.reload(safe_main)
+
+    def test_current_nonce_advances_nonce_cache(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xSafe"
+
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=9),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=23),
+            patch.object(
+                safe_main,
+                "get_safe_transactions",
+                return_value=[
+                    {"nonce": 22},
+                    {"nonce": 20},
+                    {"nonce": 23},
+                ],
+            ),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            pending = safe_main.get_pending_transactions(safe_address, "arbitrum-main")
+
+        mock_write.assert_called_once_with(safe_address, 22)
+        self.assertEqual(pending, [{"nonce": 23}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,6 +101,27 @@ class TestTelegram(unittest.TestCase):
             self.assertEqual(kwargs["json"]["text"], "Test message")
             self.assertEqual(kwargs["json"]["parse_mode"], "Markdown")
 
+    @patch("utils.telegram.requests.post")
+    def test_send_telegram_message_plain_text_omits_parse_mode(self, mock_post):
+        mock_response = unittest.mock.Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = unittest.mock.Mock()
+        mock_post.return_value = mock_response
+
+        with patch.dict(
+            os.environ,
+            {
+                "TELEGRAM_BOT_TOKEN_TEST": "test_token",
+                "TELEGRAM_CHAT_ID_TEST": "test_chat_id",
+                "LOG_LEVEL": "INFO",
+            },
+        ):
+            send_telegram_message("Test message", "test", plain_text=True)
+
+            kwargs = mock_post.call_args[1]
+            self.assertEqual(kwargs["json"]["text"], "Test message")
+            self.assertNotIn("parse_mode", kwargs["json"])
+
     @patch("utils.telegram.requests.get")
     def test_send_telegram_message_missing_credentials(self, mock_get):
         # Test with missing environment variables

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -55,9 +55,10 @@ def _post_message(
     payload: dict[str, object] = {
         "chat_id": chat_id,
         "text": message,
-        "parse_mode": "Markdown" if not plain_text else None,
         "disable_notification": disable_notification,
     }
+    if not plain_text:
+        payload["parse_mode"] = "Markdown"
     if topic_id:
         payload["message_thread_id"] = int(topic_id)
 


### PR DESCRIPTION
## Summary
- persist the Safe on-chain nonce baseline when fetched successfully so stale cache entries cannot resurrect old pending Safe txs after a transient nonce-fetch timeout
- omit Telegram parse_mode for plain-text sends instead of sending null
- add focused coverage for Safe nonce cache advancement and plain-text Telegram payloads

## Tests
- /srv/monitoring/.venv/bin/python -m unittest tests.test_safe_main tests.test_utils
- /srv/monitoring/.venv/bin/python -m compileall safe/main.py tests/test_safe_main.py utils/telegram.py tests/test_utils.py