### PR TITLE
Fix stale governance proposal alerts

### DIFF
--- a/aave/proposals.py
+++ b/aave/proposals.py
@@ -10,6 +10,8 @@ from utils.telegram import send_telegram_message
 
 PROTOCOL = "aave"
 logger = get_logger(PROTOCOL)
+AAVE_GOVERNANCE_EXECUTED_STATE = 4
+AAVE_GOVERNANCE_CACHE_API = "https://governance-cache-api.aave.com/graphql"
 
 
 def run_query(query: str, variables: dict) -> dict | None:
@@ -45,10 +47,15 @@ def run_query(query: str, variables: dict) -> dict | None:
 
 def fetch_queued_proposals(last_reported_id: int):
     # state: 3 is queued state: https://github.com/bgd-labs/aave-governance-v3/blob/0c14d60ac89d7a9f79d0a1f77de5c99c3ba1201f/src/interfaces/IGovernanceCore.sol#L75
-    # queued state is transferred to active state when it's executed, few seconds later so we need to check state 4
+    # state: 4 is executed. Aave Governance execution queues proposal payloads in their PayloadsController.
     query = """
-        query($lastId: Int!) {
-            proposals(where:{state:4, proposalId_gt:$lastId}) {
+        query($lastId: Int!, $executedState: Int!) {
+            proposals(
+                where:{state:$executedState, proposalId_gt:$lastId}
+                orderBy: proposalId
+                orderDirection: desc
+                first: 10
+            ) {
                 proposalId
                 proposalMetadata{
                     title
@@ -58,18 +65,61 @@ def fetch_queued_proposals(last_reported_id: int):
                         timestamp
                     }
                 }
+                payloads{
+                    id
+                    chainId
+                    payloadsController
+                }
             }
         }
     """
 
-    # get only last 10 proposals
-    variables = {"lastId": last_reported_id}
+    variables = {"lastId": last_reported_id, "executedState": AAVE_GOVERNANCE_EXECUTED_STATE}
     response = run_query(query, variables)
     if response is None:
         return []
 
     proposals = response["data"]["proposals"]
-    return proposals
+    return sorted(proposals, key=lambda proposal: int(proposal["proposalId"]))
+
+
+def fetch_payload_states(proposal_id: int) -> list[dict]:
+    query = """
+        query GetProposalPayloads($proposalId: String!) {
+            getProposalPayloads(pProposalId: $proposalId) {
+                nodes {
+                    proposalId
+                    payloadId
+                    chainId
+                    state
+                    queuedAt
+                    executedAt
+                    cancelledAt
+                }
+            }
+        }
+    """
+    response = request_with_retry(
+        "post",
+        AAVE_GOVERNANCE_CACHE_API,
+        json={"query": query, "variables": {"proposalId": str(proposal_id)}},
+    )
+    data = response.json()
+    if "errors" in data:
+        raise ValueError(f"Aave governance cache API error: {data['errors']}")
+    return data["data"]["getProposalPayloads"]["nodes"]
+
+
+def has_pending_payload(proposal: dict) -> bool:
+    proposal_id = int(proposal["proposalId"])
+    payload_states = fetch_payload_states(proposal_id)
+    if not payload_states:
+        logger.info("Proposal: %s has no payload cache data", proposal_id)
+        return False
+
+    # The app shows proposals like 489 as still pending while any payload is not
+    # executed yet. Fully executed proposals like 488 should not alert again.
+    return any(payload.get("state") != "executed" for payload in payload_states)
 
 
 def handle_governance_proposals():
@@ -81,6 +131,7 @@ def handle_governance_proposals():
 
     aave_url = "https://app.aave.com/governance/v3/proposal/?proposalId="
     message = ""
+    newest_reported_id = last_sent_id
     for proposal in proposals:
         timestamp = int(proposal["transactions"]["executed"]["timestamp"])
         proposal_id = int(proposal["proposalId"])
@@ -88,12 +139,17 @@ def handle_governance_proposals():
             logger.info("Proposal: %s already reported", proposal["proposalId"])
             continue
 
+        if not has_pending_payload(proposal):
+            logger.info("Proposal: %s has no pending payloads", proposal["proposalId"])
+            continue
+
+        newest_reported_id = max(newest_reported_id, proposal_id)
         date_time = datetime.fromtimestamp(timestamp)
-        timestamp = date_time.strftime("%Y-%m-%d %H:%M:%S")
+        formatted_timestamp = date_time.strftime("%Y-%m-%d %H:%M:%S")
         message += (
             f"📕 Title: {proposal['proposalMetadata']['title']}\n"
             f"🆔 ID: {proposal['proposalId']}\n"
-            f"🕒 Queued at: {timestamp}\n"
+            f"🕒 Queued at: {formatted_timestamp}\n"
             f"🔗 Link to Proposal: {aave_url + proposal['proposalId']}\n\n"
         )
 
@@ -103,7 +159,7 @@ def handle_governance_proposals():
 
     message = "🖋️ Queued Aave Governance Proposals 🖋️\n" + message
     send_telegram_message(message, PROTOCOL)
-    write_last_queued_id_to_file(PROTOCOL, proposals[-1]["proposalId"])
+    write_last_queued_id_to_file(PROTOCOL, newest_reported_id)
 
 
 if __name__ == "__main__":

--- a/compound/proposals.py
+++ b/compound/proposals.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from utils.cache import get_last_queued_id_from_file, write_last_queued_id_to_file
 from utils.logging import get_logger
-from utils.telegram import send_telegram_message
+from utils.telegram import escape_markdown, send_telegram_message
 
 load_dotenv()
 
@@ -89,6 +89,7 @@ def get_proposals():
             TALLY_API_URL,
             json={"query": query, "variables": variables},
             headers=headers,
+            timeout=30,
         )
         response.raise_for_status()
         data = response.json()
@@ -114,12 +115,14 @@ def get_proposals():
             return
 
         message = "🖋️ Compound Governance Proposals 🖋️\n"
+        newest_reported_proposal_id = last_reported_id
         for proposal in queued_proposals:
             proposal_id = int(proposal["onchainId"])
             if proposal_id <= last_reported_id:
                 # use continue instead of break because Comp can have unordered proposal ids
                 continue
 
+            newest_reported_proposal_id = max(newest_reported_proposal_id, proposal_id)
             link = COMPOUND_TALLY_URL + str(proposal_id)
             message += f"📗 Proposal ID: {proposal_id}\n"
             message += f"🔗 Link to Proposal: {link}\n"
@@ -127,7 +130,7 @@ def get_proposals():
             metadata = proposal["metadata"]
             title = extract_title_from_metadata(metadata["title"])
             if title:
-                message += f"📝 Title: {title}\n"
+                message += f"📝 Title: {escape_markdown(title)}\n"
             # if description:
             #     summary = extract_summary_from_description(description)
             #     if summary:
@@ -135,10 +138,14 @@ def get_proposals():
 
         send_telegram_message(message, PROTOCOL)
         # write the last reported id (highest ID since we sorted ascending)
-        write_last_queued_id_to_file(PROTOCOL, newest_queued_proposal_id)
+        write_last_queued_id_to_file(PROTOCOL, newest_reported_proposal_id)
 
     except requests.RequestException as e:
         message = f"Failed to fetch compound proposals: {e}"
+        send_telegram_message(message, PROTOCOL, disable_notification=True, plain_text=True)
+    except Exception as e:
+        message = f"Error processing compound proposals: {e}"
+        logger.error("%s", message)
         send_telegram_message(message, PROTOCOL, disable_notification=True, plain_text=True)
 
 

--- a/fluid/proposals.py
+++ b/fluid/proposals.py
@@ -70,6 +70,9 @@ def get_proposals():
             return
 
         proposals = data["data"]
+        if not isinstance(proposals, list):
+            raise ValueError("Fluid API returned invalid proposals payload")
+
         logger.info("Found %s queued proposals", len(proposals))
 
         # Sort proposals by id from lowest to highest
@@ -84,6 +87,7 @@ def get_proposals():
 
         message = "🏛️ Fluid Protocol Governance Proposals 🏛️\n"
         new_proposals_found = False
+        newest_reported_proposal_id = last_reported_id
 
         for proposal in proposals:
             proposal_id = int(proposal["id"])
@@ -91,6 +95,7 @@ def get_proposals():
                 continue
 
             new_proposals_found = True
+            newest_reported_proposal_id = max(newest_reported_proposal_id, proposal_id)
             link = FLUID_PROPOSAL_URL + str(proposal_id)
             message += f"📗 Proposal ID: {proposal_id}\n"
             message += f"🔗 Link: [Proposal {proposal_id}]({link})\n"
@@ -119,7 +124,7 @@ def get_proposals():
 
         if new_proposals_found:
             send_telegram_message(message, PROTOCOL)
-            write_last_queued_id_to_file(PROTOCOL, newest_proposal_id)
+            write_last_queued_id_to_file(PROTOCOL, newest_reported_proposal_id)
         else:
             logger.info("No new proposals to report")
 

--- a/maker/proposals.py
+++ b/maker/proposals.py
@@ -4,7 +4,7 @@ import requests
 
 from utils.cache import get_last_queued_id_from_file, write_last_queued_id_to_file
 from utils.logging import get_logger
-from utils.telegram import send_telegram_message
+from utils.telegram import escape_markdown, send_telegram_message
 
 PROTOCOL = "maker"
 logger = get_logger(PROTOCOL)
@@ -28,8 +28,8 @@ def get_proposals():
             logger.info("No executive proposals found")
             return
 
-        # Sort by date ascending so we process oldest first
-        proposals.sort(key=lambda p: p["date"])
+        # Sort by date ascending so we process oldest first.
+        proposals = sorted(proposals, key=lambda p: p["date"])
 
         # Cache stores epoch timestamp of the latest reported proposal date
         last_reported_timestamp = get_last_queued_id_from_file(PROTOCOL)
@@ -43,7 +43,7 @@ def get_proposals():
             if proposal_timestamp <= last_reported_timestamp:
                 continue
 
-            spell_data = proposal.get("spellData", {})
+            spell_data = proposal.get("spellData") or {}
 
             # Only alert on scheduled (not yet executed) proposals
             if not spell_data.get("hasBeenScheduled") or spell_data.get("hasBeenCast"):
@@ -51,9 +51,9 @@ def get_proposals():
 
             link = SKY_EXECUTIVE_URL + proposal["key"]
 
-            message += f"📕 Title: {proposal['title']}\n"
+            message += f"📕 Title: {escape_markdown(proposal['title'])}\n"
             if proposal.get("proposalBlurb"):
-                blurb = proposal["proposalBlurb"]
+                blurb = escape_markdown(proposal["proposalBlurb"])
                 if len(blurb) > 450:
                     blurb = blurb[:450].rsplit(" ", 1)[0] + "..."
                 message += f"📝 Summary: {blurb}\n"

--- a/tests/test_aave_proposals.py
+++ b/tests/test_aave_proposals.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+
+from aave.proposals import fetch_queued_proposals, handle_governance_proposals, has_pending_payload
+
+
+def _payload(chain_id: int = 1, payload_id: int = 1) -> dict:
+    return {
+        "id": f"{chain_id}_{payload_id}",
+        "chainId": str(chain_id),
+        "payloadsController": "0xdabad81af85554e9ae636395611c58f7ec1aaec5",
+    }
+
+
+def _proposal(proposal_id: int, timestamp: int, title: str = "Test Proposal", payloads: list[dict] | None = None) -> dict:
+    return {
+        "proposalId": str(proposal_id),
+        "proposalMetadata": {"title": title},
+        "transactions": {"executed": {"timestamp": str(timestamp)}},
+        "payloads": payloads or [_payload(payload_id=proposal_id)],
+    }
+
+
+def test_aave_fetches_executed_governance_proposals_with_payloads():
+    payload = {"data": {"proposals": [_proposal(12, 1), _proposal(10, 1)]}}
+
+    with patch("aave.proposals.run_query", return_value=payload) as mock_run_query:
+        proposals = fetch_queued_proposals(9)
+
+    query, variables = mock_run_query.call_args.args
+    assert "state:$executedState" in query
+    assert "orderDirection: desc" in query
+    assert "first: 10" in query
+    assert "payloads" in query
+    assert variables == {"lastId": 9, "executedState": 4}
+    assert [proposal["proposalId"] for proposal in proposals] == ["10", "12"]
+
+
+def test_aave_handler_alerts_governance_executed_proposals_with_pending_payloads():
+    proposals = [
+        _proposal(489, 1_800_000_000 - 60, "Passed Proposal"),
+        _proposal(488, 1_800_000_000 - 120, "Already Executed Proposal"),
+    ]
+
+    with (
+        patch("aave.proposals.get_last_queued_id_from_file", return_value=487),
+        patch("aave.proposals.fetch_queued_proposals", return_value=proposals),
+        patch("aave.proposals.has_pending_payload", side_effect=[True, False]),
+        patch("aave.proposals.send_telegram_message") as mock_send,
+        patch("aave.proposals.write_last_queued_id_to_file") as mock_write,
+    ):
+        handle_governance_proposals()
+
+    mock_send.assert_called_once()
+    message, protocol = mock_send.call_args.args
+    assert protocol == "aave"
+    assert "Passed Proposal" in message
+    assert "Already Executed Proposal" not in message
+    mock_write.assert_called_once_with("aave", 489)
+
+
+def test_aave_has_pending_payload_is_true_when_any_payload_is_not_executed():
+    proposal = _proposal(489, 1)
+    payload_states = [
+        {"payloadId": "442", "chainId": "1", "state": "executed"},
+        {"payloadId": "4", "chainId": "196", "state": "created"},
+    ]
+
+    with patch("aave.proposals.fetch_payload_states", return_value=payload_states):
+        assert has_pending_payload(proposal)
+
+
+def test_aave_has_pending_payload_is_false_when_all_payloads_are_executed():
+    proposal = _proposal(488, 1)
+    payload_states = [{"payloadId": "443", "chainId": "1", "state": "executed"}]
+
+    with patch("aave.proposals.fetch_payload_states", return_value=payload_states):
+        assert not has_pending_payload(proposal)

--- a/tests/test_compound_proposals.py
+++ b/tests/test_compound_proposals.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+import requests
+
+from compound.proposals import get_proposals
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def test_compound_alert_uses_timeout_escapes_title_and_updates_reported_id():
+    payload = {
+        "data": {
+            "proposals": {
+                "nodes": [
+                    {
+                        "onchainId": "42",
+                        "status": "queued",
+                        "metadata": {"title": "# Update COMP_USDC *market*", "description": ""},
+                    },
+                    {
+                        "onchainId": "41",
+                        "status": "active",
+                        "metadata": {"title": "Active proposal", "description": ""},
+                    },
+                ]
+            }
+        }
+    }
+
+    with (
+        patch("compound.proposals.requests.post", return_value=_Response(payload)) as mock_post,
+        patch("compound.proposals.get_last_queued_id_from_file", return_value=40),
+        patch("compound.proposals.send_telegram_message") as mock_send,
+        patch("compound.proposals.write_last_queued_id_to_file") as mock_write,
+    ):
+        get_proposals()
+
+    assert mock_post.call_args.kwargs["timeout"] == 30
+    mock_send.assert_called_once()
+    message, protocol = mock_send.call_args.args
+    assert protocol == "comp"
+    assert "Update COMP\\_USDC \\*market\\*" in message
+    assert "Active proposal" not in message
+    mock_write.assert_called_once_with("comp", 42)
+
+
+def test_compound_processing_error_alert_uses_plain_text():
+    with (
+        patch("compound.proposals.requests.post", return_value=_Response({"data": {}})),
+        patch("compound.proposals.send_telegram_message") as mock_send,
+    ):
+        get_proposals()
+
+    mock_send.assert_called_once()
+    message, protocol = mock_send.call_args.args
+    assert message.startswith("Error processing compound proposals:")
+    assert protocol == "comp"
+    assert mock_send.call_args.kwargs == {"disable_notification": True, "plain_text": True}
+
+
+def test_compound_fetch_error_alert_uses_plain_text():
+    with (
+        patch("compound.proposals.requests.post", side_effect=requests.Timeout("timed out")),
+        patch("compound.proposals.send_telegram_message") as mock_send,
+    ):
+        get_proposals()
+
+    mock_send.assert_called_once_with(
+        "Failed to fetch compound proposals: timed out",
+        "comp",
+        disable_notification=True,
+        plain_text=True,
+    )

--- a/tests/test_maker_proposals.py
+++ b/tests/test_maker_proposals.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch
+
+from maker.proposals import get_proposals
+
+
+def test_maker_alerts_scheduled_uncast_executives_and_escapes_markdown():
+    proposals = [
+        {
+            "key": "scheduled",
+            "title": "Update PSM_USDC_A *rates*",
+            "proposalBlurb": "This touches TYPE_1 params and [links].",
+            "date": "2026-05-01T00:00:00.000Z",
+            "spellData": {"hasBeenScheduled": True, "hasBeenCast": False, "eta": "2026-05-02T00:00:00.000Z"},
+        },
+        {
+            "key": "cast",
+            "title": "Already cast",
+            "date": "2026-05-02T00:00:00.000Z",
+            "spellData": {"hasBeenScheduled": True, "hasBeenCast": True},
+        },
+        {
+            "key": "unscheduled",
+            "title": "Not scheduled",
+            "date": "2026-05-03T00:00:00.000Z",
+            "spellData": {"hasBeenScheduled": False, "hasBeenCast": False},
+        },
+    ]
+
+    with (
+        patch("maker.proposals.fetch_executive_proposals", return_value=proposals),
+        patch("maker.proposals.get_last_queued_id_from_file", return_value=0),
+        patch("maker.proposals.send_telegram_message") as mock_send,
+        patch("maker.proposals.write_last_queued_id_to_file") as mock_write,
+    ):
+        get_proposals()
+
+    mock_send.assert_called_once()
+    message, protocol = mock_send.call_args.args
+    assert protocol == "maker"
+    assert "Update PSM\\_USDC\\_A \\*rates\\*" in message
+    assert "TYPE\\_1 params and \\[links]." in message
+    assert "Already cast" not in message
+    assert "Not scheduled" not in message
+    mock_write.assert_called_once_with("maker", 1777593600)
+
+
+def test_maker_does_not_cache_when_only_new_executives_are_not_actionable():
+    proposals = [
+        {
+            "key": "unscheduled",
+            "title": "Not scheduled",
+            "date": "2026-05-03T00:00:00.000Z",
+            "spellData": {"hasBeenScheduled": False, "hasBeenCast": False},
+        }
+    ]
+
+    with (
+        patch("maker.proposals.fetch_executive_proposals", return_value=proposals),
+        patch("maker.proposals.get_last_queued_id_from_file", return_value=0),
+        patch("maker.proposals.send_telegram_message") as mock_send,
+        patch("maker.proposals.write_last_queued_id_to_file") as mock_write,
+    ):
+        get_proposals()
+
+    mock_send.assert_not_called()
+    mock_write.assert_not_called()


### PR DESCRIPTION
## Summary
- fix Aave proposal monitor to alert only governance-executed proposals that still have pending payloads, using Aave governance cache API payload state across chains
- exclude cancelled proposals and fully executed payload sets like proposal 488, while including pending examples like proposal 489
- harden Maker, Fluid, and Compound proposal monitors around cache updates, Markdown escaping, payload validation, timeouts, and processing errors
- add focused proposal monitor regression tests

## Verification
Aave Governance v3 state Executed = 4 means vote results were sent and payloads were created/queued, not necessarily that every payload has executed. The monitor now fetches governance-executed proposals from the subgraph, then checks Aave governance cache payload states and only reports proposals where at least one payload is not executed.

Local debug run updated /srv/cache/cache-id.txt to aave:489 with Telegram skipped by LOG_LEVEL=DEBUG.

## Tests
- uv run --extra dev pytest tests/test_aave_proposals.py tests/test_fluid_proposals.py tests/test_maker_proposals.py tests/test_compound_proposals.py -q
- uv run ruff check aave/proposals.py fluid/proposals.py maker/proposals.py compound/proposals.py tests/test_aave_proposals.py tests/test_fluid_proposals.py tests/test_maker_proposals.py tests/test_compound_proposals.py