### PR TITLE
Improve Morpho V2 cap alert market labels

### DIFF
--- a/protocols/morpho/_shared.py
+++ b/protocols/morpho/_shared.py
@@ -58,7 +58,7 @@ def get_chain_name(chain: Chain) -> str:
 
 def get_market_url(market_id: str, chain: Chain) -> str:
     """Build the Morpho UI URL for a market by its marketId."""
-    return f"{MORPHO_URL}/{get_chain_name(chain)}/market/{market_id}"
+    return f"{MORPHO_URL}/{get_chain_name(chain)}/market/{market_id}/"
 
 
 def get_vault_url(vault_address: str, chain: Chain) -> str:
@@ -66,15 +66,14 @@ def get_vault_url(vault_address: str, chain: Chain) -> str:
     return f"{MORPHO_URL}/{get_chain_name(chain)}/vault/{vault_address}"
 
 
-def fetch_market_name(market_id: str, chain: Chain) -> str:
-    """Fetch a human-readable name like 'WBTC/USDC (86.00%)' for a market_id.
+def fetch_market_metadata(market_id: str, chain: Chain) -> dict[str, Any] | None:
+    """Fetch symbols and loan decimals for a Morpho market.
 
-    Falls back to the raw market_id on error so alerts always render.
+    Returns None on error so alert rendering can fall back to decoded calldata.
     """
     query = """
     query GetMarket($marketId: String!, $chainId: Int!) {
         marketById(marketId: $marketId, chainId: $chainId) {
-            lltv
             loanAsset { symbol, decimals }
             collateralAsset { symbol }
         }
@@ -88,12 +87,24 @@ def fetch_market_name(market_id: str, chain: Chain) -> str:
         )
         market = response.json()["data"]["marketById"]
         collateral_symbol = market["collateralAsset"]["symbol"] if market.get("collateralAsset") else "idle"
-        loan_symbol = market["loanAsset"]["symbol"]
-        lltv_pct = int(market["lltv"]) / 1e18 * 100
-        return f"{collateral_symbol}/{loan_symbol} ({lltv_pct:.2f}%)"
+        loan_asset = market["loanAsset"]
+        return {
+            "name": f"{collateral_symbol}/{loan_asset['symbol']}",
+            "loan_symbol": loan_asset["symbol"],
+            "loan_decimals": int(loan_asset["decimals"]),
+        }
     except Exception as e:
-        logger.warning("Failed to fetch market name for %s: %s", market_id, e)
-        return market_id
+        logger.warning("Failed to fetch market metadata for %s: %s", market_id, e)
+        return None
+
+
+def fetch_market_name(market_id: str, chain: Chain) -> str:
+    """Fetch a human-readable name like 'WBTC/USDC' for a market_id.
+
+    Falls back to the raw market_id on error so alerts always render.
+    """
+    metadata = fetch_market_metadata(market_id, chain)
+    return metadata["name"] if metadata else market_id
 
 
 @dataclass(frozen=True)

--- a/protocols/morpho/governance_v2.py
+++ b/protocols/morpho/governance_v2.py
@@ -251,11 +251,11 @@ def _explorer_link(chain: Chain, tx_hash: str) -> str:
 
 
 def _alert_pending_new(snapshot: V2GovernanceSnapshot, pc: PendingConfig) -> None:
-    decoded = decode_submit(pc.data)
+    decoded = decode_submit(pc.data, snapshot.chain)
     send_telegram_message(
         f"⏳ V2 [{snapshot.name}]({get_vault_url(snapshot.address, snapshot.chain)}) "
         f"on {snapshot.chain.name}\n"
-        f"📥 Submitted: `{decoded}`\n"
+        f"📥 Submitted: {decoded}\n"
         f"⏰ Executable at: {_format_ts(pc.valid_at)}\n"
         f"🔗 Tx: {_explorer_link(snapshot.chain, pc.tx_hash)}",
         PROTOCOL,

--- a/protocols/morpho/v2_decoders.py
+++ b/protocols/morpho/v2_decoders.py
@@ -18,7 +18,10 @@ from eth_abi import decode as abi_decode
 from eth_utils import to_checksum_address
 from web3 import Web3
 
+from protocols.morpho._shared import fetch_market_metadata, get_market_url
 from utils.calldata.decoder import resolve_selector
+from utils.chains import Chain
+from utils.formatting import format_token_amount, format_with_suffix
 from utils.logging import get_logger
 
 logger = get_logger("morpho.v2_decoders")
@@ -91,7 +94,19 @@ def _format_wad_pct(value: int) -> str:
     return f"{value / WAD * 100:.4f}%"
 
 
-def decode_id_data(id_data: bytes) -> str:
+def _format_cap_amount(cap: int, decimals: int | None, symbol: str | None = None) -> str:
+    if decimals is None:
+        amount = f"{cap:,}"
+    else:
+        amount = format_with_suffix(format_token_amount(cap, decimals))
+    return f"{amount} {symbol}" if symbol else amount
+
+
+def _market_id_from_params(loan: str, collateral: str, oracle: str, irm: str, lltv: int) -> str:
+    return "0x" + bytes(Web3.keccak(_encode_market_params(loan, collateral, oracle, irm, lltv))).hex()
+
+
+def decode_id_data(id_data: bytes, chain: Chain | None = None) -> str:
     """Decode a cap-setter ``bytes idData`` argument.
 
     The Morpho V2 cap system uses three id-tag prefixes, ABI-encoded as a leading
@@ -115,9 +130,13 @@ def decode_id_data(id_data: bytes) -> str:
     else:
         if tag == "this/marketParams":
             loan, collateral, oracle, irm, lltv = market_params
-            market_id_hex = bytes(Web3.keccak(_encode_market_params(loan, collateral, oracle, irm, lltv))).hex()
+            market_id = _market_id_from_params(loan, collateral, oracle, irm, lltv)
+            if chain is not None:
+                metadata = fetch_market_metadata(market_id, chain)
+                if metadata:
+                    return f"market [{metadata['name']}]({get_market_url(market_id, chain)})"
             return (
-                f"market `0x{market_id_hex}` "
+                f"market `{market_id}` "
                 f"(loan {_format_address(loan)}, collateral {_format_address(collateral)}, "
                 f"lltv {lltv / WAD * 100:.2f}%) on adapter {_format_address(adapter)}"
             )
@@ -134,6 +153,25 @@ def decode_id_data(id_data: bytes) -> str:
     return f"id tag '{tag}' addr {_format_address(addr)}"
 
 
+def _format_cap_change(id_data: bytes, new_cap: int, chain: Chain | None = None) -> str:
+    market_params_type = "(address,address,address,address,uint256)"
+    if chain is not None:
+        try:
+            tag, _adapter, market_params = abi_decode(["string", "address", market_params_type], id_data)
+        except Exception:
+            tag = None
+        else:
+            if tag == "this/marketParams":
+                loan, collateral, oracle, irm, lltv = market_params
+                market_id = _market_id_from_params(loan, collateral, oracle, irm, lltv)
+                metadata = fetch_market_metadata(market_id, chain)
+                if metadata:
+                    cap = _format_cap_amount(new_cap, metadata["loan_decimals"], metadata["loan_symbol"])
+                    return f"market [{metadata['name']}]({get_market_url(market_id, chain)}) → cap {cap}"
+
+    return f"{decode_id_data(id_data)} → cap {new_cap}"
+
+
 def _encode_market_params(loan: str, collateral: str, oracle: str, irm: str, lltv: int) -> bytes:
     """Re-encode MarketParams in the canonical Morpho Blue form for hashing."""
     from eth_abi import encode as abi_encode
@@ -144,7 +182,7 @@ def _encode_market_params(loan: str, collateral: str, oracle: str, irm: str, llt
     )
 
 
-def _format_args(sig: str, args: tuple[Any, ...]) -> str:  # noqa: PLR0911,PLR0912
+def _format_args(sig: str, args: tuple[Any, ...], chain: Chain | None = None) -> str:  # noqa: PLR0911,PLR0912
     """Render a decoded argument tuple per signature."""
     name = _function_name(sig)
 
@@ -167,7 +205,7 @@ def _format_args(sig: str, args: tuple[Any, ...]) -> str:  # noqa: PLR0911,PLR09
         return _format_address(addr)
     if name in ("increaseAbsoluteCap", "increaseRelativeCap"):
         id_data, new_cap = args
-        return f"{decode_id_data(id_data)} → cap {new_cap}"
+        return _format_cap_change(id_data, new_cap, chain)
     if name in ("increaseTimelock", "decreaseTimelock"):
         sel_bytes, duration = args
         return f"{_resolve_inner_selector(sel_bytes)} → {duration}s"
@@ -198,7 +236,7 @@ def _arg_types(sig: str) -> list[str]:
     return [t.strip() for t in inner.split(",")]
 
 
-def decode_submit(data: bytes) -> str:
+def decode_submit(data: bytes, chain: Chain | None = None) -> str:
     """Render a Submit/Accept/Revoke ``data`` payload as a function call string.
 
     Falls back to a Sourcify 4byte lookup for unknown selectors so we never
@@ -223,7 +261,7 @@ def decode_submit(data: bytes) -> str:
         logger.warning("Failed to ABI-decode %s payload: %s", sig, e)
         return f"{_function_name(sig)}(<undecoded args 0x{data[4:].hex()}>)"
 
-    return f"{_function_name(sig)}({_format_args(sig, args)})"
+    return f"{_function_name(sig)}({_format_args(sig, args, chain)})"
 
 
 def submit_data_key(data: bytes) -> str:

--- a/tests/test_morpho_v2_decoders.py
+++ b/tests/test_morpho_v2_decoders.py
@@ -6,6 +6,7 @@ each timelocked selector on VaultV2 and MorphoMarketV1AdapterV2.
 """
 
 import unittest
+from unittest.mock import patch
 
 from eth_abi import encode as abi_encode
 from web3 import Web3
@@ -17,6 +18,7 @@ from protocols.morpho.v2_decoders import (
     selector_function_name,
     submit_data_key,
 )
+from utils.chains import Chain
 
 ZERO_ADDR = "0x" + "00" * 20
 A1 = "0x" + "11" * 20
@@ -191,6 +193,29 @@ class TestDecodeIdData(unittest.TestCase):
         self.assertIn("increaseAbsoluteCap", decoded)
         self.assertIn("lltv 91.00%", decoded)
         self.assertIn(f"cap {1_000_000 * 10**6}", decoded)
+
+    def test_increase_absolute_cap_with_market_params_and_chain_links_market(self):
+        market_params = (A1, A2, A3, A4, 91 * 10**16)
+        id_data = abi_encode(
+            ["string", "address", "(address,address,address,address,uint256)"],
+            ["this/marketParams", A5, market_params],
+        )
+        new_cap = 80_000_000 * 10**18
+        data = _build(
+            "increaseAbsoluteCap(bytes,uint256)",
+            ["bytes", "uint256"],
+            [id_data, new_cap],
+        )
+
+        metadata = {"name": "wstUSR/RLUSD", "loan_symbol": "RLUSD", "loan_decimals": 18}
+        with patch("protocols.morpho.v2_decoders.fetch_market_metadata", return_value=metadata):
+            decoded = decode_submit(data, Chain.MAINNET)
+
+        self.assertRegex(decoded, r"market \[wstUSR/RLUSD\]\(https://app\.morpho\.org/ethereum/market/0x[0-9a-f]{64}/\)")
+        self.assertNotIn("lltv", decoded)
+        self.assertNotIn(f"loan {Web3.to_checksum_address(A1)}", decoded)
+        self.assertNotIn(f"adapter {Web3.to_checksum_address(A5)}", decoded)
+        self.assertIn("cap 80.00M RLUSD", decoded)
 
     def test_increase_relative_cap_with_collateral_tag(self):
         id_data = abi_encode(["string", "address"], ["collateralToken", A1])

--- a/tests/test_morpho_v2_decoders.py
+++ b/tests/test_morpho_v2_decoders.py
@@ -211,7 +211,9 @@ class TestDecodeIdData(unittest.TestCase):
         with patch("protocols.morpho.v2_decoders.fetch_market_metadata", return_value=metadata):
             decoded = decode_submit(data, Chain.MAINNET)
 
-        self.assertRegex(decoded, r"market \[wstUSR/RLUSD\]\(https://app\.morpho\.org/ethereum/market/0x[0-9a-f]{64}/\)")
+        self.assertRegex(
+            decoded, r"market \[wstUSR/RLUSD\]\(https://app\.morpho\.org/ethereum/market/0x[0-9a-f]{64}/\)"
+        )
         self.assertNotIn("lltv", decoded)
         self.assertNotIn(f"loan {Web3.to_checksum_address(A1)}", decoded)
         self.assertNotIn(f"adapter {Web3.to_checksum_address(A5)}", decoded)


### PR DESCRIPTION
## Summary
- resolve Morpho V2 cap market params through the Morpho API
- render cap alerts with clickable collateral/loan market labels and formatted loan-token caps
- remove inline-code wrapping so market links render in Telegram

## Tests
- /srv/monitoring/.venv/bin/python -m unittest tests.test_morpho_v2_decoders
- /srv/monitoring/.venv/bin/python -m compileall protocols/morpho tests/test_morpho_v2_decoders.py
- git diff --check