### PR TITLE
fix(aave): migrate proposals.py to governance cache API

### DIFF
--- a/automation/jobs.yaml
+++ b/automation/jobs.yaml
@@ -43,11 +43,7 @@ profiles:
       - { name: "maple",                  script: protocols/maple/main.py }
       - { name: "timelock-alerts",        script: protocols/timelock/timelock_alerts.py }
       # proposals scripts must run AFTER timelock-alerts (cache dedupe ordering).
-      # Disabled 2026-06-10: Graph subgraph A7QMsz… has no healthy indexers
-      # (gateway returns BadResponse 400 / Unavailable) — errors hourly. Re-enable
-      # when the decentralized network recovers, or after migrating to
-      # governance-cache-api.aave.com.
-      - { name: "aave-proposals",         script: protocols/aave/proposals.py, enabled: false }
+      - { name: "aave-proposals",         script: protocols/aave/proposals.py }
       - { name: "ustb",                   script: protocols/ustb/main.py }
       - { name: "compound-proposals",     script: protocols/compound/proposals.py }
       - { name: "fluid-proposals",        script: protocols/fluid/proposals.py }

--- a/protocols/aave/proposals.py
+++ b/protocols/aave/proposals.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 
 import requests
@@ -10,12 +9,17 @@ from utils.telegram import send_error_message, send_telegram_message
 
 PROTOCOL = "aave"
 logger = get_logger(PROTOCOL)
-AAVE_GOVERNANCE_EXECUTED_STATE = 4
+
+# Aave's official governance cache API. Replaces the decentralized-network
+# subgraph (gateway-arbitrum), whose indexers stopped serving the governance
+# deployment and returned BadResponse(400)/Unavailable on every query.
 AAVE_GOVERNANCE_CACHE_API = "https://governance-cache-api.aave.com/graphql"
+# State string returned by the cache API for executed proposals/payloads.
+EXECUTED_STATE = "executed"
 
 
 def run_query(query: str, variables: dict) -> dict | None:
-    """Run a GraphQL query against The Graph API with retry logic.
+    """Run a GraphQL query against the Aave governance cache API with retry logic.
 
     Args:
         query: The GraphQL query string.
@@ -24,19 +28,16 @@ def run_query(query: str, variables: dict) -> dict | None:
     Returns:
         Parsed JSON response dict, or None on failure.
     """
-    api_key = os.getenv("GRAPH_API_KEY")
-    subgraph_id = "A7QMszgomC9cnnfpAcqZVLr2DffvkGNfimD8iUSMiurK"
-    url = f"https://gateway-arbitrum.network.thegraph.com/api/{api_key}/subgraphs/id/{subgraph_id}"
     request_body = {"query": query, "variables": variables}
 
     try:
-        response = request_with_retry("post", url, json=request_body)
+        response = request_with_retry("post", AAVE_GOVERNANCE_CACHE_API, json=request_body)
     except requests.RequestException as e:
-        logger.error("Graph API query failed after retries: %s", e)
-        send_error_message(f"Graph API query failed after retries: {e}", PROTOCOL)
+        logger.error("Aave governance cache API query failed after retries: %s", e)
+        send_error_message(f"Aave governance cache API query failed after retries: {e}", PROTOCOL)
         return None
 
-    data = response.json()
+    data: dict = response.json()
     if "errors" in data:
         logger.error("GraphQL error in response: %s", data["errors"])
         send_error_message(f"GraphQL error in response: {data['errors']}", PROTOCOL)
@@ -45,45 +46,52 @@ def run_query(query: str, variables: dict) -> dict | None:
     return data
 
 
-def fetch_queued_proposals(last_reported_id: int):
-    # state: 3 is queued state: https://github.com/bgd-labs/aave-governance-v3/blob/0c14d60ac89d7a9f79d0a1f77de5c99c3ba1201f/src/interfaces/IGovernanceCore.sol#L75
-    # state: 4 is executed. Aave Governance execution queues proposal payloads in their PayloadsController.
+def fetch_queued_proposals(last_reported_id: int) -> list[dict]:
+    """Fetch recently executed governance proposals newer than ``last_reported_id``.
+
+    A proposal reaches the ``executed`` state once governance execution queues its
+    payloads in the PayloadsController of each target chain; ``has_pending_payload``
+    then decides whether any of those payloads is still awaiting execution.
+
+    Args:
+        last_reported_id: Highest proposal id already reported.
+
+    Returns:
+        Executed proposals with id greater than ``last_reported_id``, sorted by
+        ascending proposal id. Each dict carries ``proposalId``, ``title`` and ``state``.
+    """
     query = """
-        query($lastId: Int!, $executedState: Int!) {
-            proposals(
-                where:{state:$executedState, proposalId_gt:$lastId}
-                orderBy: proposalId
-                orderDirection: desc
-                first: 10
-            ) {
-                proposalId
-                proposalMetadata{
+        query($state: String!, $limit: Int!) {
+            getProposalsByState(stateFilter: $state, limitCount: $limit) {
+                nodes {
+                    proposalId
                     title
-                }
-                transactions{
-                    executed{
-                        timestamp
-                    }
-                }
-                payloads{
-                    id
-                    chainId
-                    payloadsController
+                    state
                 }
             }
         }
     """
 
-    variables = {"lastId": last_reported_id, "executedState": AAVE_GOVERNANCE_EXECUTED_STATE}
+    variables = {"state": EXECUTED_STATE, "limit": 10}
     response = run_query(query, variables)
     if response is None:
         return []
 
-    proposals = response["data"]["proposals"]
+    nodes = response["data"]["getProposalsByState"]["nodes"]
+    proposals = [proposal for proposal in nodes if int(proposal["proposalId"]) > last_reported_id]
     return sorted(proposals, key=lambda proposal: int(proposal["proposalId"]))
 
 
 def fetch_payload_states(proposal_id: int) -> list[dict]:
+    """Fetch the per-chain payload execution states for a proposal.
+
+    Args:
+        proposal_id: Governance proposal id.
+
+    Returns:
+        Payload state nodes (one per payload), each with ``state``, ``queuedAt``,
+        ``executedAt`` and ``cancelledAt`` ISO-8601 timestamps.
+    """
     query = """
         query GetProposalPayloads($proposalId: String!) {
             getProposalPayloads(pProposalId: $proposalId) {
@@ -107,22 +115,36 @@ def fetch_payload_states(proposal_id: int) -> list[dict]:
     data = response.json()
     if "errors" in data:
         raise ValueError(f"Aave governance cache API error: {data['errors']}")
-    return data["data"]["getProposalPayloads"]["nodes"]
+    nodes: list[dict] = data["data"]["getProposalPayloads"]["nodes"]
+    return nodes
 
 
-def has_pending_payload(proposal: dict) -> bool:
-    proposal_id = int(proposal["proposalId"])
-    payload_states = fetch_payload_states(proposal_id)
+def has_pending_payload(payload_states: list[dict]) -> bool:
+    """Return True when any payload of a proposal has not executed yet.
+
+    The app shows proposals like 489 as still pending while any payload is not
+    executed; fully executed proposals like 488 should not alert again.
+
+    Args:
+        payload_states: Payload state nodes from ``fetch_payload_states``.
+    """
     if not payload_states:
-        logger.info("Proposal: %s has no payload cache data", proposal_id)
         return False
-
-    # The app shows proposals like 489 as still pending while any payload is not
-    # executed yet. Fully executed proposals like 488 should not alert again.
-    return any(payload.get("state") != "executed" for payload in payload_states)
+    return any(payload.get("state") != EXECUTED_STATE for payload in payload_states)
 
 
-def handle_governance_proposals():
+def earliest_queued_at(payload_states: list[dict]) -> datetime | None:
+    """Return the earliest ``queuedAt`` across a proposal's payloads, if any.
+
+    Args:
+        payload_states: Payload state nodes from ``fetch_payload_states``.
+    """
+    queued = [datetime.fromisoformat(p["queuedAt"]) for p in payload_states if p.get("queuedAt")]
+    return min(queued) if queued else None
+
+
+def handle_governance_proposals() -> None:
+    """Alert on executed Aave proposals whose payloads are still queued."""
     last_sent_id = get_last_queued_id_from_file(PROTOCOL)
     proposals = fetch_queued_proposals(last_sent_id)
     if not proposals:
@@ -133,21 +155,21 @@ def handle_governance_proposals():
     message = ""
     newest_reported_id = last_sent_id
     for proposal in proposals:
-        timestamp = int(proposal["transactions"]["executed"]["timestamp"])
         proposal_id = int(proposal["proposalId"])
         if proposal_id <= last_sent_id:
             logger.info("Proposal: %s already reported", proposal["proposalId"])
             continue
 
-        if not has_pending_payload(proposal):
+        payload_states = fetch_payload_states(proposal_id)
+        if not has_pending_payload(payload_states):
             logger.info("Proposal: %s has no pending payloads", proposal["proposalId"])
             continue
 
         newest_reported_id = max(newest_reported_id, proposal_id)
-        date_time = datetime.fromtimestamp(timestamp)
-        formatted_timestamp = date_time.strftime("%Y-%m-%d %H:%M:%S")
+        queued_at = earliest_queued_at(payload_states)
+        formatted_timestamp = queued_at.strftime("%Y-%m-%d %H:%M:%S UTC") if queued_at else "unknown"
         message += (
-            f"📕 Title: {proposal['proposalMetadata']['title']}\n"
+            f"📕 Title: {proposal['title']}\n"
             f"🆔 ID: {proposal['proposalId']}\n"
             f"🕒 Queued at: {formatted_timestamp}\n"
             f"🔗 Link to Proposal: {aave_url + proposal['proposalId']}\n\n"

--- a/protocols/aave/proposals.py
+++ b/protocols/aave/proposals.py
@@ -14,8 +14,13 @@ logger = get_logger(PROTOCOL)
 # subgraph (gateway-arbitrum), whose indexers stopped serving the governance
 # deployment and returned BadResponse(400)/Unavailable on every query.
 AAVE_GOVERNANCE_CACHE_API = "https://governance-cache-api.aave.com/graphql"
-# State string returned by the cache API for executed proposals/payloads.
-EXECUTED_STATE = "executed"
+# Proposal-level state in the cache API: governance execution has queued the
+# payloads, but the proposal stays "queued" until every payload has executed
+# (it only flips to "executed" once all are done). These are the proposals to
+# alert on — distinct from the payload-level "executed" check below.
+QUEUED_PROPOSAL_STATE = "queued"
+# Payload-level state: an individual payload has executed on its target chain.
+EXECUTED_PAYLOAD_STATE = "executed"
 
 
 def run_query(query: str, variables: dict) -> dict | None:
@@ -47,17 +52,18 @@ def run_query(query: str, variables: dict) -> dict | None:
 
 
 def fetch_queued_proposals(last_reported_id: int) -> list[dict]:
-    """Fetch recently executed governance proposals newer than ``last_reported_id``.
+    """Fetch queued governance proposals newer than ``last_reported_id``.
 
-    A proposal reaches the ``executed`` state once governance execution queues its
-    payloads in the PayloadsController of each target chain; ``has_pending_payload``
-    then decides whether any of those payloads is still awaiting execution.
+    A proposal is ``queued`` once governance execution has queued its payloads in
+    the PayloadsController of each target chain and at least one payload is still
+    awaiting execution; once every payload executes it flips to ``executed``.
+    ``has_pending_payload`` re-confirms a payload is still pending before alerting.
 
     Args:
         last_reported_id: Highest proposal id already reported.
 
     Returns:
-        Executed proposals with id greater than ``last_reported_id``, sorted by
+        Queued proposals with id greater than ``last_reported_id``, sorted by
         ascending proposal id. Each dict carries ``proposalId``, ``title`` and ``state``.
     """
     query = """
@@ -72,7 +78,7 @@ def fetch_queued_proposals(last_reported_id: int) -> list[dict]:
         }
     """
 
-    variables = {"state": EXECUTED_STATE, "limit": 10}
+    variables = {"state": QUEUED_PROPOSAL_STATE, "limit": 10}
     response = run_query(query, variables)
     if response is None:
         return []
@@ -130,7 +136,7 @@ def has_pending_payload(payload_states: list[dict]) -> bool:
     """
     if not payload_states:
         return False
-    return any(payload.get("state") != EXECUTED_STATE for payload in payload_states)
+    return any(payload.get("state") != EXECUTED_PAYLOAD_STATE for payload in payload_states)
 
 
 def earliest_queued_at(payload_states: list[dict]) -> datetime | None:

--- a/tests/test_aave_proposals.py
+++ b/tests/test_aave_proposals.py
@@ -1,52 +1,63 @@
 from unittest.mock import patch
 
-from protocols.aave.proposals import fetch_queued_proposals, handle_governance_proposals, has_pending_payload
+from protocols.aave.proposals import (
+    earliest_queued_at,
+    fetch_queued_proposals,
+    handle_governance_proposals,
+    has_pending_payload,
+)
 
 
-def _payload(chain_id: int = 1, payload_id: int = 1) -> dict:
-    return {
-        "id": f"{chain_id}_{payload_id}",
-        "chainId": str(chain_id),
-        "payloadsController": "0xdabad81af85554e9ae636395611c58f7ec1aaec5",
-    }
+def _proposal(proposal_id: int, title: str = "Test Proposal", state: str = "executed") -> dict:
+    return {"proposalId": str(proposal_id), "title": title, "state": state}
 
 
-def _proposal(
-    proposal_id: int, timestamp: int, title: str = "Test Proposal", payloads: list[dict] | None = None
+def _payload_state(
+    state: str = "executed",
+    queued_at: str | None = "2026-05-26T10:30:35+00:00",
+    payload_id: int = 1,
+    chain_id: int = 1,
 ) -> dict:
     return {
-        "proposalId": str(proposal_id),
-        "proposalMetadata": {"title": title},
-        "transactions": {"executed": {"timestamp": str(timestamp)}},
-        "payloads": payloads or [_payload(payload_id=proposal_id)],
+        "proposalId": "1",
+        "payloadId": str(payload_id),
+        "chainId": str(chain_id),
+        "state": state,
+        "queuedAt": queued_at,
+        "executedAt": None,
+        "cancelledAt": None,
     }
 
 
-def test_aave_fetches_executed_governance_proposals_with_payloads():
-    payload = {"data": {"proposals": [_proposal(12, 1), _proposal(10, 1)]}}
+def test_aave_fetches_executed_governance_proposals():
+    payload = {"data": {"getProposalsByState": {"nodes": [_proposal(12), _proposal(10), _proposal(9)]}}}
 
     with patch("protocols.aave.proposals.run_query", return_value=payload) as mock_run_query:
         proposals = fetch_queued_proposals(9)
 
     query, variables = mock_run_query.call_args.args
-    assert "state:$executedState" in query
-    assert "orderDirection: desc" in query
-    assert "first: 10" in query
-    assert "payloads" in query
-    assert variables == {"lastId": 9, "executedState": 4}
+    assert "getProposalsByState" in query
+    assert "stateFilter: $state" in query
+    assert variables == {"state": "executed", "limit": 10}
+    # id 9 is filtered out (not > 9); remainder sorted ascending.
     assert [proposal["proposalId"] for proposal in proposals] == ["10", "12"]
 
 
 def test_aave_handler_alerts_governance_executed_proposals_with_pending_payloads():
     proposals = [
-        _proposal(489, 1_800_000_000 - 60, "Passed Proposal"),
-        _proposal(488, 1_800_000_000 - 120, "Already Executed Proposal"),
+        _proposal(488, "Already Executed Proposal"),
+        _proposal(489, "Passed Proposal"),
+    ]
+    fully_executed = [_payload_state(state="executed")]
+    still_pending = [
+        _payload_state(state="executed", chain_id=1),
+        _payload_state(state="created", chain_id=196, payload_id=4, queued_at="2026-05-27T08:00:00+00:00"),
     ]
 
     with (
         patch("protocols.aave.proposals.get_last_queued_id_from_file", return_value=487),
         patch("protocols.aave.proposals.fetch_queued_proposals", return_value=proposals),
-        patch("protocols.aave.proposals.has_pending_payload", side_effect=[True, False]),
+        patch("protocols.aave.proposals.fetch_payload_states", side_effect=[fully_executed, still_pending]),
         patch("protocols.aave.proposals.send_telegram_message") as mock_send,
         patch("protocols.aave.proposals.write_last_queued_id_to_file") as mock_write,
     ):
@@ -57,23 +68,32 @@ def test_aave_handler_alerts_governance_executed_proposals_with_pending_payloads
     assert protocol == "aave"
     assert "Passed Proposal" in message
     assert "Already Executed Proposal" not in message
+    assert "2026-05-26 10:30:35 UTC" in message
     mock_write.assert_called_once_with("aave", 489)
 
 
 def test_aave_has_pending_payload_is_true_when_any_payload_is_not_executed():
-    proposal = _proposal(489, 1)
     payload_states = [
         {"payloadId": "442", "chainId": "1", "state": "executed"},
         {"payloadId": "4", "chainId": "196", "state": "created"},
     ]
-
-    with patch("protocols.aave.proposals.fetch_payload_states", return_value=payload_states):
-        assert has_pending_payload(proposal)
+    assert has_pending_payload(payload_states)
 
 
 def test_aave_has_pending_payload_is_false_when_all_payloads_are_executed():
-    proposal = _proposal(488, 1)
-    payload_states = [{"payloadId": "443", "chainId": "1", "state": "executed"}]
+    assert not has_pending_payload([{"payloadId": "443", "chainId": "1", "state": "executed"}])
 
-    with patch("protocols.aave.proposals.fetch_payload_states", return_value=payload_states):
-        assert not has_pending_payload(proposal)
+
+def test_aave_has_pending_payload_is_false_when_no_payloads():
+    assert not has_pending_payload([])
+
+
+def test_aave_earliest_queued_at_returns_min_timestamp():
+    states = [
+        _payload_state(queued_at="2026-05-27T08:00:00+00:00"),
+        _payload_state(queued_at="2026-05-26T10:30:35+00:00"),
+        _payload_state(queued_at=None),
+    ]
+    queued = earliest_queued_at(states)
+    assert queued is not None
+    assert queued.strftime("%Y-%m-%d %H:%M:%S") == "2026-05-26 10:30:35"

--- a/tests/test_aave_proposals.py
+++ b/tests/test_aave_proposals.py
@@ -8,7 +8,7 @@ from protocols.aave.proposals import (
 )
 
 
-def _proposal(proposal_id: int, title: str = "Test Proposal", state: str = "executed") -> dict:
+def _proposal(proposal_id: int, title: str = "Test Proposal", state: str = "queued") -> dict:
     return {"proposalId": str(proposal_id), "title": title, "state": state}
 
 
@@ -29,7 +29,7 @@ def _payload_state(
     }
 
 
-def test_aave_fetches_executed_governance_proposals():
+def test_aave_fetches_queued_governance_proposals():
     payload = {"data": {"getProposalsByState": {"nodes": [_proposal(12), _proposal(10), _proposal(9)]}}}
 
     with patch("protocols.aave.proposals.run_query", return_value=payload) as mock_run_query:
@@ -38,7 +38,7 @@ def test_aave_fetches_executed_governance_proposals():
     query, variables = mock_run_query.call_args.args
     assert "getProposalsByState" in query
     assert "stateFilter: $state" in query
-    assert variables == {"state": "executed", "limit": 10}
+    assert variables == {"state": "queued", "limit": 10}
     # id 9 is filtered out (not > 9); remainder sorted ascending.
     assert [proposal["proposalId"] for proposal in proposals] == ["10", "12"]
 


### PR DESCRIPTION
## Summary

`protocols/aave/proposals.py` queried the Aave governance subgraph (`A7QMsz…`) on The Graph's decentralized network. Its indexers stopped serving that deployment, so the gateway returns `BadResponse(400)`/`Unavailable` and the script errored on **every hourly run** (the alert that surfaced this).

This migrates the proposal listing to Aave's **official `governance-cache-api.aave.com`** — the same API the script already used for payload states — and re-enables the task that was disabled in `ffda749` to stop the noise.

## Changes
- `fetch_queued_proposals` now uses `getProposalsByState(stateFilter: "queued")` instead of the dead subgraph.
  - **Review catch:** the cache API's proposal state is a higher-level aggregate than the old subgraph's state:4. A proposal stays **"queued"** while any payload is still pending and only flips to **"executed"** once all payloads execute. Querying "executed" would return already-complete proposals, so `has_pending_payload` skipped them all and the monitor would silently never alert. Querying "queued" targets the correct set of proposals that still have pending payloads.
- Payload-level state check (`has_pending_payload`) remains against `"executed"` to confirm a payload is still pending before alerting.
- Queued timestamp now derived from the payloads' on-chain `queuedAt` (ISO/UTC) — slightly more accurate for the "Queued at" label than the old governance-execution time.
- Dropped the fetched-but-unused `payloads` subgraph field and the now-unneeded `GRAPH_API_KEY`/subgraph plumbing.
- Re-enabled the `aave-proposals` task in `automation/jobs.yaml`.
- Updated `tests/test_aave_proposals.py` to the new response shapes/signatures and the corrected `queued` state.

## Verification
- `ruff check` / `ruff format` clean
- `mypy` clean on the file (only a pre-existing `utils/http.py` baseline error remains)
- `pytest tests/test_aave_proposals.py` — 6 passing
- Live dry run against the cache API: with `last_sent_id=487`, the monitor correctly alerts on queued proposal 489 (pending payloads on chains 196/9745). Prod cache is at 489 and the stuck-queued backlog (473–487) is all ≤ 489, so re-enabling does not flood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)