### PR TITLE
Use Wavey Gist for AI detail links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ LLM_PROVIDER=venice
 LLM_API_KEY=your-llm-api-key
 # LLM_BASE_URL=https://api.venice.ai/api/v1  # auto-set for known providers
 # LLM_MODEL=deepseek-v4-flash  # auto-set for known providers
+WAVEY_GIST_API_KEY=your-wavey-gist-api-key
 
 # Dune (hourly large-transfer monitor)
 DUNE_API_KEY=your-dune-api-key

--- a/scripts/diagnose_telegram_400.py
+++ b/scripts/diagnose_telegram_400.py
@@ -33,7 +33,6 @@ MAINNET = r"""⏰ *TIMELOCK: New Operation Scheduled*
 
 🤖 *AI Summary:*
 Adds a new CCTPStrategy to the Yearn V3 yvUSD vault and caps its debt at 100,000 USDC (6-decimal). Strategy inclusion without a prior safety review is routine for Yearn, and the max debt limit is moderate. No funds move immediately; the strategy becomes available for future deposits. LOW
-[Full details](https://dpaste.com/HFHDQLQD3)
 🔗 Tx: [0xa6e8a54c3ff514951bca921cc38af55278980937816e5d04cd2d88fcf406199c](https://etherscan.io/tx/0xa6e8a54c3ff514951bca921cc38af55278980937816e5d04cd2d88fcf406199c)"""
 
 # Base — scheduled 2026-05-27 18:04 UTC, op 0xe8c04f74b9b8bd6687
@@ -48,7 +47,6 @@ BASE = r"""⏰ *TIMELOCK: New Operation Scheduled*
 
 🤖 *AI Summary:*
 Sets the minimum timelock delay to 604800 seconds (7 days). This applies to all future scheduled operations, slowing the pace at which any governance action can be executed. No assets are moved and no roles are changed. LOW
-[Full details](https://dpaste.com/6HXK57BEG)
 🔗 Tx: [0x7c03e52b297ffc6d73ddcc7ed14621295f76d058f82d96b734185c182b717a7a](https://basescan.org/tx/0x7c03e52b297ffc6d73ddcc7ed14621295f76d058f82d96b734185c182b717a7a)"""
 
 bot_token = os.environ["TELEGRAM_BOT_TOKEN_DEFAULT"]

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -549,8 +549,8 @@ class TestParseExplanation(unittest.TestCase):
 class TestFormatExplanationLine(unittest.TestCase):
     """Tests for format_explanation_line."""
 
-    @patch("utils.llm.ai_explainer.upload_to_paste", return_value="https://gist.wavey.info/abc123")
-    def test_format_with_detail(self, mock_paste: MagicMock) -> None:
+    @patch("utils.llm.ai_explainer.upload_to_gist", return_value="https://gist.wavey.info/abc123")
+    def test_format_with_detail(self, mock_gist: MagicMock) -> None:
         explanation = Explanation(summary="This pauses the protocol.", detail="Full detail here.")
         result = format_explanation_line(explanation)
         self.assertIn("AI Summary", result)
@@ -558,11 +558,11 @@ class TestFormatExplanationLine(unittest.TestCase):
         self.assertNotIn("Full detail here.", result)
         self.assertIn("https://gist.wavey.info/abc123", result)
         self.assertIn("Full details", result)
-        mock_paste.assert_called_once_with("Full detail here.", title="AI Transaction Analysis")
+        mock_gist.assert_called_once_with("Full detail here.", title="AI Transaction Analysis")
 
-    @patch("utils.llm.ai_explainer.upload_to_paste", return_value="")
-    def test_format_paste_failure(self, mock_paste: MagicMock) -> None:
-        """If paste upload fails, surface a notice instead of a link."""
+    @patch("utils.llm.ai_explainer.upload_to_gist", return_value="")
+    def test_format_gist_failure(self, mock_gist: MagicMock) -> None:
+        """If gist upload fails, surface a notice instead of a link."""
         explanation = Explanation(summary="This pauses the protocol.", detail="Full detail here.")
         result = format_explanation_line(explanation)
         self.assertIn("AI Summary", result)
@@ -571,7 +571,7 @@ class TestFormatExplanationLine(unittest.TestCase):
         self.assertIn("Couldn't post full report", result)
 
     def test_format_no_detail(self) -> None:
-        """If there's no detail, no paste upload is attempted."""
+        """If there's no detail, no gist upload is attempted."""
         explanation = Explanation(summary="This pauses the protocol.", detail="")
         result = format_explanation_line(explanation)
         self.assertIn("AI Summary", result)

--- a/tests/test_ai_explainer.py
+++ b/tests/test_ai_explainer.py
@@ -549,14 +549,14 @@ class TestParseExplanation(unittest.TestCase):
 class TestFormatExplanationLine(unittest.TestCase):
     """Tests for format_explanation_line."""
 
-    @patch("utils.llm.ai_explainer.upload_to_paste", return_value="https://rentry.co/abc123")
+    @patch("utils.llm.ai_explainer.upload_to_paste", return_value="https://gist.wavey.info/abc123")
     def test_format_with_detail(self, mock_paste: MagicMock) -> None:
         explanation = Explanation(summary="This pauses the protocol.", detail="Full detail here.")
         result = format_explanation_line(explanation)
         self.assertIn("AI Summary", result)
         self.assertIn("This pauses the protocol.", result)
         self.assertNotIn("Full detail here.", result)
-        self.assertIn("https://rentry.co/abc123", result)
+        self.assertIn("https://gist.wavey.info/abc123", result)
         self.assertIn("Full details", result)
         mock_paste.assert_called_once_with("Full detail here.", title="AI Transaction Analysis")
 

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -8,22 +8,12 @@ import requests
 from utils.paste import upload_to_paste
 
 
-def _mock_session(*, csrftoken: str = "tok", post_json: dict | None = None) -> MagicMock:
-    """Build a mock requests.Session for the rentry CSRF flow."""
-    session = MagicMock()
-    session.__enter__.return_value = session
-    session.__exit__.return_value = False
-    session.cookies.get.return_value = csrftoken
-
-    get_resp = MagicMock()
-    get_resp.raise_for_status.return_value = None
-    session.get.return_value = get_resp
-
-    post_resp = MagicMock()
-    post_resp.raise_for_status.return_value = None
-    post_resp.json.return_value = post_json or {"status": "200", "url": "https://rentry.co/abc123"}
-    session.post.return_value = post_resp
-    return session
+def _mock_response(*, post_json: dict | None = None) -> MagicMock:
+    """Build a mock Wavey Gist response."""
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = post_json or {"url": "https://gist.wavey.info/abc123", "id": "abc123"}
+    return response
 
 
 class TestUploadToPaste(unittest.TestCase):
@@ -32,50 +22,46 @@ class TestUploadToPaste(unittest.TestCase):
     def test_empty_content_returns_empty(self) -> None:
         self.assertEqual(upload_to_paste(""), "")
 
-    @patch("utils.paste.requests.Session")
-    def test_successful_upload(self, mock_session_cls: MagicMock) -> None:
-        session = _mock_session()
-        mock_session_cls.return_value = session
+    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.paste.requests.post")
+    def test_successful_upload(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = _mock_response()
 
         result = upload_to_paste("Some **markdown**", title="Test")
-        self.assertEqual(result, "https://rentry.co/abc123")
+        self.assertEqual(result, "https://gist.wavey.info/abc123")
 
-        # Title is prepended as a markdown heading, csrftoken echoed back.
-        data = session.post.call_args[1]["data"]
-        self.assertEqual(data["text"], "# Test\n\nSome **markdown**")
-        self.assertEqual(data["csrfmiddlewaretoken"], "tok")
-        self.assertEqual(session.post.call_args[1]["headers"]["Referer"], "https://rentry.co")
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["title"], "Test")
+        self.assertEqual(payload["markdown"], "# Test\n\nSome **markdown**")
+        self.assertEqual(mock_post.call_args[1]["headers"]["Authorization"], "Bearer test-key")
 
-    @patch("utils.paste.requests.Session")
-    def test_no_title_sends_raw_content(self, mock_session_cls: MagicMock) -> None:
-        session = _mock_session()
-        mock_session_cls.return_value = session
+    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.paste.requests.post")
+    def test_no_title_sends_raw_content(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = _mock_response()
 
         upload_to_paste("Content only")
-        self.assertEqual(session.post.call_args[1]["data"]["text"], "Content only")
+        payload = mock_post.call_args[1]["json"]
+        self.assertEqual(payload["title"], "Monitoring Details")
+        self.assertEqual(payload["markdown"], "Content only")
 
-    @patch("utils.paste.requests.Session")
-    def test_missing_csrftoken_returns_empty(self, mock_session_cls: MagicMock) -> None:
-        session = _mock_session(csrftoken=None)
-        mock_session_cls.return_value = session
-
+    @patch.dict("utils.paste.os.environ", {}, clear=True)
+    @patch("utils.paste.requests.post")
+    def test_missing_api_key_returns_empty(self, mock_post: MagicMock) -> None:
         self.assertEqual(upload_to_paste("x"), "")
-        session.post.assert_not_called()
+        mock_post.assert_not_called()
 
-    @patch("utils.paste.requests.Session")
-    def test_non_200_status_returns_empty(self, mock_session_cls: MagicMock) -> None:
-        session = _mock_session(post_json={"status": "400", "errors": "bad request"})
-        mock_session_cls.return_value = session
-
+    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.paste.requests.post")
+    def test_missing_url_returns_empty(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = _mock_response(post_json={"id": "abc123"})
         self.assertEqual(upload_to_paste("x"), "")
 
-    @patch("utils.paste.requests.Session")
-    def test_request_failure_returns_empty(self, mock_session_cls: MagicMock) -> None:
-        session = _mock_session()
-        session.post.side_effect = requests.RequestException("Connection error")
-        mock_session_cls.return_value = session
-
-        self.assertEqual(upload_to_paste("Some content"), "")
+    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.paste.requests.post")
+    def test_request_failure_returns_empty(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = requests.RequestException("Connection error")
+        self.assertEqual(upload_to_paste("x"), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_wavey_gist.py
+++ b/tests/test_wavey_gist.py
@@ -1,11 +1,11 @@
-"""Tests for utils/paste.py."""
+"""Tests for utils/wavey_gist.py."""
 
 import unittest
 from unittest.mock import MagicMock, patch
 
 import requests
 
-from utils.paste import upload_to_paste
+from utils.wavey_gist import upload_to_gist
 
 
 def _mock_response(*, post_json: dict | None = None) -> MagicMock:
@@ -16,18 +16,18 @@ def _mock_response(*, post_json: dict | None = None) -> MagicMock:
     return response
 
 
-class TestUploadToPaste(unittest.TestCase):
-    """Tests for upload_to_paste."""
+class TestUploadToGist(unittest.TestCase):
+    """Tests for upload_to_gist."""
 
     def test_empty_content_returns_empty(self) -> None:
-        self.assertEqual(upload_to_paste(""), "")
+        self.assertEqual(upload_to_gist(""), "")
 
-    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.paste.requests.post")
+    @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.wavey_gist.requests.post")
     def test_successful_upload(self, mock_post: MagicMock) -> None:
         mock_post.return_value = _mock_response()
 
-        result = upload_to_paste("Some **markdown**", title="Test")
+        result = upload_to_gist("Some **markdown**", title="Test")
         self.assertEqual(result, "https://gist.wavey.info/abc123")
 
         payload = mock_post.call_args[1]["json"]
@@ -35,33 +35,33 @@ class TestUploadToPaste(unittest.TestCase):
         self.assertEqual(payload["markdown"], "# Test\n\nSome **markdown**")
         self.assertEqual(mock_post.call_args[1]["headers"]["Authorization"], "Bearer test-key")
 
-    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.paste.requests.post")
+    @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.wavey_gist.requests.post")
     def test_no_title_sends_raw_content(self, mock_post: MagicMock) -> None:
         mock_post.return_value = _mock_response()
 
-        upload_to_paste("Content only")
+        upload_to_gist("Content only")
         payload = mock_post.call_args[1]["json"]
         self.assertEqual(payload["title"], "Monitoring Details")
         self.assertEqual(payload["markdown"], "Content only")
 
-    @patch.dict("utils.paste.os.environ", {}, clear=True)
-    @patch("utils.paste.requests.post")
+    @patch.dict("utils.wavey_gist.os.environ", {}, clear=True)
+    @patch("utils.wavey_gist.requests.post")
     def test_missing_api_key_returns_empty(self, mock_post: MagicMock) -> None:
-        self.assertEqual(upload_to_paste("x"), "")
+        self.assertEqual(upload_to_gist("x"), "")
         mock_post.assert_not_called()
 
-    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.paste.requests.post")
+    @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.wavey_gist.requests.post")
     def test_missing_url_returns_empty(self, mock_post: MagicMock) -> None:
         mock_post.return_value = _mock_response(post_json={"id": "abc123"})
-        self.assertEqual(upload_to_paste("x"), "")
+        self.assertEqual(upload_to_gist("x"), "")
 
-    @patch.dict("utils.paste.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
-    @patch("utils.paste.requests.post")
+    @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.wavey_gist.requests.post")
     def test_request_failure_returns_empty(self, mock_post: MagicMock) -> None:
         mock_post.side_effect = requests.RequestException("Connection error")
-        self.assertEqual(upload_to_paste("x"), "")
+        self.assertEqual(upload_to_gist("x"), "")
 
 
 if __name__ == "__main__":

--- a/utils/llm/README.md
+++ b/utils/llm/README.md
@@ -210,7 +210,7 @@ The full prompt is logged at INFO level for debugging.
 
 ### 7. Two-Stage Generation: Summary, then Detail Derived From It
 
-`_generate_explanation()` produces the `Explanation` dataclass (`summary` → Telegram, `detail` → paste service) in two stages so the two artifacts the team sees can never disagree on the headline number or risk verdict:
+`_generate_explanation()` produces the `Explanation` dataclass (`summary` → Telegram, `detail` → Wavey Gist) in two stages so the two artifacts the team sees can never disagree on the headline number or risk verdict:
 
 1. **Summary (authoritative).** `_generate_summary()` produces just the `summary` + `risk_tag`.
 2. **Detail (derived).** `_expand_detail()` then writes the full report *from* the confirmed summary (`DETAIL_EXPANSION_TASK`), required to stay consistent with its magnitudes and risk level.
@@ -252,10 +252,10 @@ Cost: ~1 extra LLM call per alert when enabled. Default is **off**.
 ```
 🤖 *AI Summary:*
 Upgrades AAVE pool impl 0xOld → 0xNew. Verify audited. MEDIUM.
-[Full details](https://dpaste.org/abc123)
+[Full details](https://gist.wavey.info/abc123)
 ```
 
-The "Full details" link points to a dpaste.org upload with the detailed analysis.
+The "Full details" link points to a Wavey Gist upload with the detailed analysis.
 
 ## Configuration
 
@@ -268,6 +268,7 @@ All configuration is via environment variables:
 | `LLM_MODEL` | `deepseek-v4-flash` | Model identifier |
 | `LLM_BASE_URL` | *(per provider)* | API base URL (not needed for anthropic) |
 | `LLM_STRUCTURED_OUTPUT` | *(per provider)* | `true`/`false` to force JSON-schema output. Default: on for anthropic/openai/venice (all verified live), off for groq/custom |
+| `WAVEY_GIST_API_KEY` | *(required for detail links)* | API key for publishing detailed AI reports to Wavey Gist |
 | `ETHERSCAN_TOKEN` | *(optional)* | Etherscan v2 multichain API key for source context |
 | `TENDERLY_API_KEY` | *(optional)* | Tenderly API key for simulation |
 | `TENDERLY_ACCOUNT` | `yearn` | Tenderly account slug |

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -17,7 +17,6 @@ from utils.llm import get_llm_provider
 from utils.llm.base import LLMError, LLMProvider
 from utils.logging import get_logger
 from utils.on_chain_state import StateRead, format_state_reads, read_before_state
-from utils.paste import upload_to_paste
 from utils.proxy import build_diff_url, detect_proxy_upgrade, get_current_implementation
 from utils.risk_anchors import format_anchors_block
 from utils.risk_anchors import lookup as lookup_risk_anchor
@@ -32,6 +31,7 @@ from utils.source_context import (
 )
 from utils.telegram import escape_markdown
 from utils.tenderly.simulation import SimulationResult, simulate_transaction
+from utils.wavey_gist import upload_to_gist
 
 logger = get_logger("utils.llm.ai_explainer")
 
@@ -1300,7 +1300,7 @@ def format_explanation_line(explanation: Explanation) -> str:
     """
     line = f"\n🤖 *AI Summary:*\n{escape_markdown(explanation.summary)}"
     if explanation.detail:
-        detail_url = upload_to_paste(explanation.detail, title=DETAIL_REPORT_TITLE)
+        detail_url = upload_to_gist(explanation.detail, title=DETAIL_REPORT_TITLE)
         if detail_url:
             line += f"\n[Full details]({detail_url})"
         else:

--- a/utils/llm/ai_explainer.py
+++ b/utils/llm/ai_explainer.py
@@ -114,6 +114,7 @@ The summary need not repeat the risk tag; the risk_tag field carries it."""
 SYSTEM_INSTRUCTIONS_SUMMARY_JSON = SYSTEM_PROMPT + JSON_SUMMARY_NOTE
 
 _RISK_TAGS = ("LOW", "MEDIUM", "HIGH", "CRITICAL")
+DETAIL_REPORT_TITLE = "AI Transaction Analysis"
 
 # JSON Schema for stage 1 (summary + risk_tag only). risk_tag is enum-constrained so
 # the Telegram tag is always valid — no regex extraction or fallback parsing needed.
@@ -1295,13 +1296,13 @@ def format_explanation_line(explanation: Explanation) -> str:
     """Format the AI explanation for inclusion in a Telegram alert message.
 
     Uses the short summary for the Telegram message. The detailed analysis
-    is uploaded to a paste service (rentry.co) for easy access.
+    is uploaded to Wavey Gist for easy access.
     """
     line = f"\n🤖 *AI Summary:*\n{escape_markdown(explanation.summary)}"
     if explanation.detail:
-        paste_url = upload_to_paste(explanation.detail, title="AI Transaction Analysis")
-        if paste_url:
-            line += f"\n[Full details]({paste_url})"
+        detail_url = upload_to_paste(explanation.detail, title=DETAIL_REPORT_TITLE)
+        if detail_url:
+            line += f"\n[Full details]({detail_url})"
         else:
             line += "\n⚠️ Couldn't post full report"
     return line

--- a/utils/paste.py
+++ b/utils/paste.py
@@ -1,9 +1,6 @@
-"""Upload markdown text to rentry.co and return the URL.
+"""Upload markdown text to Wavey Gist and return the public URL."""
 
-rentry.co renders markdown and accepts anonymous pastes through a small CSRF
-flow: fetch the ``csrftoken`` cookie from the site, then POST the content with
-the matching ``csrfmiddlewaretoken`` field and a ``Referer`` header.
-"""
+import os
 
 import requests
 
@@ -11,12 +8,11 @@ from utils.logging import get_logger
 
 logger = get_logger("utils.paste")
 
-RENTRY_BASE_URL = "https://rentry.co"
-RENTRY_API_NEW_URL = f"{RENTRY_BASE_URL}/api/new"
+WAVEY_GIST_API_URL = "https://api.wavey.info/api/v1/gists"
 
 
 def upload_to_paste(content: str, title: str = "") -> str:
-    """Upload markdown ``content`` to rentry.co and return the rendered-page URL.
+    """Upload markdown ``content`` to Wavey Gist and return the rendered-page URL.
 
     Args:
         content: The markdown text to upload.
@@ -28,35 +24,30 @@ def upload_to_paste(content: str, title: str = "") -> str:
     if not content:
         return ""
 
-    text = f"# {title}\n\n{content}" if title else content
-
-    try:
-        with requests.Session() as session:
-            # Priming GET sets the csrftoken cookie that the POST must echo back.
-            session.get(RENTRY_BASE_URL, timeout=10).raise_for_status()
-            csrftoken = session.cookies.get("csrftoken")
-            if not csrftoken:
-                logger.warning("Failed to upload to paste service: no csrftoken cookie from rentry")
-                return ""
-
-            response = session.post(
-                RENTRY_API_NEW_URL,
-                data={"csrfmiddlewaretoken": csrftoken, "text": text},
-                headers={"Referer": RENTRY_BASE_URL},
-                timeout=10,
-            )
-            response.raise_for_status()
-            payload = response.json()
-    except (requests.RequestException, ValueError) as e:
-        logger.warning("Failed to upload to paste service: %s", e)
+    api_key = os.getenv("WAVEY_GIST_API_KEY")
+    if not api_key:
+        logger.warning("Failed to upload to Wavey Gist: WAVEY_GIST_API_KEY is not set")
         return ""
 
-    # rentry signals success with status "200" in the JSON body; anything else
-    # carries the reason in "errors"/"content".
-    if str(payload.get("status")) != "200":
-        logger.warning("Paste service rejected upload: %s", payload.get("errors") or payload.get("content") or payload)
+    markdown = f"# {title}\n\n{content}" if title else content
+
+    try:
+        response = requests.post(
+            WAVEY_GIST_API_URL,
+            json={"title": title or "Monitoring Details", "markdown": markdown},
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as e:
+        logger.warning("Failed to upload to Wavey Gist: %s", e)
         return ""
 
     url = payload.get("url", "")
+    if not url:
+        logger.warning("Wavey Gist response did not include a URL: %s", payload)
+        return ""
+
     logger.info("Uploaded paste to %s", url)
     return url

--- a/utils/wavey_gist.py
+++ b/utils/wavey_gist.py
@@ -1,4 +1,4 @@
-"""Upload markdown text to Wavey Gist and return the public URL."""
+"""Publish markdown text to Wavey Gist and return the public URL."""
 
 import os
 
@@ -6,20 +6,21 @@ import requests
 
 from utils.logging import get_logger
 
-logger = get_logger("utils.paste")
+logger = get_logger("utils.wavey_gist")
 
 WAVEY_GIST_API_URL = "https://api.wavey.info/api/v1/gists"
+DEFAULT_GIST_TITLE = "Monitoring Details"
 
 
-def upload_to_paste(content: str, title: str = "") -> str:
-    """Upload markdown ``content`` to Wavey Gist and return the rendered-page URL.
+def upload_to_gist(content: str, title: str = "") -> str:
+    """Publish markdown ``content`` to Wavey Gist and return the rendered-page URL.
 
     Args:
         content: The markdown text to upload.
         title: Optional title, prepended as a top-level markdown heading.
 
     Returns:
-        The URL of the created paste, or an empty string on failure.
+        The URL of the created gist, or an empty string on failure.
     """
     if not content:
         return ""
@@ -34,7 +35,7 @@ def upload_to_paste(content: str, title: str = "") -> str:
     try:
         response = requests.post(
             WAVEY_GIST_API_URL,
-            json={"title": title or "Monitoring Details", "markdown": markdown},
+            json={"title": title or DEFAULT_GIST_TITLE, "markdown": markdown},
             headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
             timeout=10,
         )
@@ -49,5 +50,5 @@ def upload_to_paste(content: str, title: str = "") -> str:
         logger.warning("Wavey Gist response did not include a URL: %s", payload)
         return ""
 
-    logger.info("Uploaded paste to %s", url)
+    logger.info("Uploaded gist to %s", url)
     return url


### PR DESCRIPTION
## Summary
- replace the old anonymous paste upload flow with Wavey Gist publishing via WAVEY_GIST_API_KEY
- keep Telegram Full details links on the returned Wavey Gist URL
- rename the helper/test module around Wavey Gist and remove stale dpaste/rentry references

## Tests
- uv run pytest tests/test_wavey_gist.py tests/test_ai_explainer.py -q
- uv run ruff check utils/wavey_gist.py utils/llm/ai_explainer.py tests/test_wavey_gist.py tests/test_ai_explainer.py scripts/diagnose_telegram_400.py