### PR TITLE
fix(ethena): fall back to Ethena native API when Chaos Labs PoR is down

### DIFF
--- a/protocols/ethena/ethena.py
+++ b/protocols/ethena/ethena.py
@@ -325,10 +325,62 @@ class ChaosLabsAttestation:
     signature: str | None
 
 
+def ethena_native_backing_check() -> bool:
+    """Fallback backing-ratio check using Ethena's own transparency API.
+
+    Used when the Chaos Labs / Oracle Security attestation endpoint is unreachable
+    (e.g. provider outage). Only the quantitative backing ratio is checked here; the
+    Chaos-specific flags (delta-neutral, approved-assets-only, signed attestation) have
+    no equivalent on this source and are skipped.
+
+    Returns:
+        True if backing data was available and the check ran, False if Ethena's API
+        could not be reached either (so the caller can escalate to a hard alert).
+    """
+    supply = get_usde_supply()
+    collateral = get_total_collateral_usd()
+    if supply is None or collateral is None or supply == 0:
+        return False
+
+    # Mirror the Chaos Labs check's semantics: alert only when collateral no longer covers
+    # supply (ratio < 1). USDe targets ~1:1 collateral backing with a SEPARATE reserve fund as
+    # the buffer, so collateral-only ratios sit just above 1.0 in normal operation — applying
+    # COLLATERAL_RATIO_TRIGGER (which assumes reserve fund is included) here would false-positive.
+    backing_ratio = collateral / supply
+    if backing_ratio < 1:
+        send_alert(
+            Alert(
+                AlertSeverity.CRITICAL,
+                f"🚨 USDe NOT FULLY BACKED (Ethena API fallback)!\n"
+                f"Backing Assets: ${collateral:,.2f}\nTotal Supply: {supply:,.2f}\n"
+                f"Backing Ratio: {backing_ratio:.4f} ({backing_ratio * 100 - 100:+.2f}%)",
+                PROTOCOL,
+            )
+        )
+
+    logger.info(
+        "Ethena native API fallback – backing: $%s | supply: %s | ratio: %s",
+        f"{collateral:,.2f}",
+        f"{supply:,.2f}",
+        f"{backing_ratio:.4f}",
+    )
+    return True
+
+
 def chaos_labs_check():
     data = fetch_json(CHAOS_LABS_URL)
     if not data or not isinstance(data, list) or len(data) == 0:
-        send_error_message("⚠️ ETHENA: Failed to fetch Chaos Labs attestation data", PROTOCOL)
+        # Oracle Security / Chaos Labs PoR endpoint is unreachable (e.g. provider outage).
+        # Don't page on every run for an upstream outage we can't fix: log it and fall back
+        # to Ethena's own transparency API for the critical backing-ratio check. Only escalate
+        # to a hard alert if that fallback is also unavailable — meaning we have no backing
+        # data from any source. The Chaos-specific flags (delta-neutral, approved-assets,
+        # signature) are unavoidably skipped until the attestation endpoint recovers.
+        logger.warning("Chaos Labs attestation endpoint unavailable; falling back to Ethena native API")
+        if not ethena_native_backing_check():
+            send_error_message(
+                "⚠️ ETHENA: Failed to fetch Chaos Labs attestation data and Ethena API fallback", PROTOCOL
+            )
         return
 
     # Get the latest attestation (last item in the list)


### PR DESCRIPTION
## Problem

`[ethena] ⚠️ ETHENA: Failed to fetch Chaos Labs attestation data` is firing every run.

Root cause is an **upstream provider outage**, not a bug: `history.oraclesecurity.org` (Chaos Labs / Oracle Security PoR) returns **503** (origin unreachable behind Cloudflare; the root domain 525s). Confirmed across retries, browser UA, no-query, and both IPv4/IPv6 — so it's entirely provider-side and self-resolves when they recover.

Two consequences made this worse than a noisy alert:
1. `chaos_labs_check` sent a **hard error alert on every run** for an outage we can't fix.
2. In `__main__`, `llama_risk_check()` is commented out, so `chaos_labs_check` is the **only** check that runs — meaning USDe backing was **entirely unmonitored** during the outage.

## Change

Add `ethena_native_backing_check()` — a fallback that computes the backing ratio from **Ethena's own transparency API** (`totalBackingAssetsInUsd ÷ USDe supply`), which is reachable from the production host (the "blocked IP" NOTE was specific to GitHub Actions; the monitors run on-box).

On a Chaos Labs outage, `chaos_labs_check` now:
1. logs a warning,
2. runs the Ethena-native backing check,
3. escalates to a hard alert **only if Ethena is also unreachable** (truly no backing data from any source).

### Semantics / a bug caught in testing
The fallback alerts **CRITICAL only when ratio < 1**, matching the Chaos check's `backingAssetsUsdValueExceedsUsdeSupply`. It deliberately does **not** reuse `COLLATERAL_RATIO_TRIGGER` (1.005): that threshold assumes the reserve fund is included (as `llama_risk_check` does), whereas Ethena's collateral-only figure sits just above 1.0 in normal operation and would false-positive. (An earlier draft did exactly this and fired a spurious HIGH at the live ratio of 1.0005.)

The Chaos-specific flags (delta-neutral, approved-assets-only, signed attestation) have no equivalent source and are skipped (warning log, not a page) until the endpoint recovers.

## Verification
Exercised against the **live** Ethena API + simulated outage:

| Scenario | Behaviour |
|---|---|
| Chaos down / Ethena up (current real state, ratio 1.0005) | warning log + fallback runs → **no page, no false alert** |
| Both sources down | one consolidated error page |
| Healthy ratio | no spurious HIGH |

- `ruff check` + `ruff format --check`: pass
- `mypy`: no new errors (the 21 reported are pre-existing untyped functions in this file)
- No ethena tests exist to break

## Follow-up (not in this PR)
`llama_risk_check()` remains disabled in `__main__`. Re-enabling it would add a second independent backing source — happy to do that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)