### PR TITLE
fix(safe): retry Safe API transport errors instead of crashing

### DIFF
--- a/protocols/safe/main.py
+++ b/protocols/safe/main.py
@@ -59,7 +59,21 @@ def get_safe_transactions(
     }
 
     for attempt in range(max_retries):
-        response = requests.get(endpoint, params=params, headers=headers)
+        try:
+            response = requests.get(endpoint, params=params, headers=headers, timeout=10)
+        except requests.exceptions.RequestException as e:
+            # Transient transport failure (connection reset, read timeout, DNS).
+            # Retry with backoff instead of letting it bubble up and crash the run.
+            wait_time = 2**attempt
+            logger.warning(
+                "Request error talking to Safe API (%s), waiting %ss before retry (attempt %s/%s)...",
+                e,
+                wait_time,
+                attempt + 1,
+                max_retries,
+            )
+            time.sleep(wait_time)
+            continue
 
         if response.status_code == 200:
             return response.json()["results"]

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -1,7 +1,9 @@
 import importlib
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+
+import requests
 
 
 class TestSafePendingTransactions(unittest.TestCase):
@@ -33,6 +35,45 @@ class TestSafePendingTransactions(unittest.TestCase):
 
         mock_write.assert_called_once_with(safe_address, 22)
         self.assertEqual(pending, [{"nonce": 23}])
+
+    def test_get_safe_transactions_retries_on_connection_error(self):
+        safe_main = self._import_safe_main()
+
+        ok_response = Mock(status_code=200)
+        ok_response.json.return_value = {"results": [{"nonce": 5}]}
+
+        with (
+            patch.object(
+                safe_main.requests,
+                "get",
+                side_effect=[
+                    requests.exceptions.ConnectionError("Connection reset by peer"),
+                    ok_response,
+                ],
+            ) as mock_get,
+            patch.object(safe_main.time, "sleep") as mock_sleep,
+        ):
+            result = safe_main.get_safe_transactions("0xSafe", "arbitrum-main")
+
+        self.assertEqual(result, [{"nonce": 5}])
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_called_once()
+
+    def test_get_safe_transactions_returns_empty_after_exhausting_retries(self):
+        safe_main = self._import_safe_main()
+
+        with (
+            patch.object(
+                safe_main.requests,
+                "get",
+                side_effect=requests.exceptions.ConnectionError("Connection reset by peer"),
+            ) as mock_get,
+            patch.object(safe_main.time, "sleep"),
+        ):
+            result = safe_main.get_safe_transactions("0xSafe", "arbitrum-main", max_retries=3)
+
+        self.assertEqual(result, [])
+        self.assertEqual(mock_get.call_count, 3)
 
     def test_executed_rows_are_filtered_even_when_api_returns_them(self):
         safe_main = self._import_safe_main()


### PR DESCRIPTION
## What

`get_safe_transactions()` in `protocols/safe/main.py` retried on HTTP **429/5xx** status codes but let **transport-level** failures (`ConnectionResetError`, read timeouts, DNS) propagate uncaught. The `requests.get` also had **no timeout**.

A reset on the Safe Transaction Service (`api.safe.global`) therefore crashed the whole `safe` monitor with a bare `requests.exceptions.ConnectionError`, surfacing as:

```
[yearn] 🚨 main crashed: ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
```

The sibling `get_safe_current_nonce()` already wraps its call in try/except + `timeout=10` and degrades gracefully; this brings `get_safe_transactions()` in line.

## How

- Wrap the `requests.get` in the **existing** `max_retries` backoff loop, catching `requests.exceptions.RequestException` (covers connection reset / timeout / DNS) and retrying with the same exponential backoff used for 429/5xx.
- Add `timeout=10`, matching `get_safe_current_nonce()`.
- On exhausting retries it falls through to the existing `return []` instead of aborting the run.

## Why it matters

The `safe` task is long-running (often 150–230s, paginated across 6 networks), so a mid-run socket reset against `api.safe.global` is an expected transient. It should retry, not page the alerts channel and skip the rest of the multisig sweep.

## Testing

- `uv run pytest tests/` → **476 passed, 4 skipped**
- `uv run ruff check .` / `ruff format --check` → clean
- New tests in `tests/test_safe_main.py`:
  - retries on `ConnectionError` then succeeds (2 calls, 1 backoff sleep)
  - returns `[]` after exhausting `max_retries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)