### PR TITLE
fix(safe): dedupe cache write to highest nonce + per-call filter diagnostic

### DIFF
--- a/protocols/safe/main.py
+++ b/protocols/safe/main.py
@@ -119,6 +119,16 @@ def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]
     - Dead-slot: nonce < safe.currentNonce. These remain in the API as
       ``executed=false`` because a competing tx at the same nonce executed
       first, but they will never run themselves.
+
+    The baseline is the higher of (a) the last nonce we already alerted on
+    and (b) ``currentNonce - 1`` (the last *executed* nonce, when we could
+    fetch it). A tx is eligible iff ``nonce > baseline``.
+
+    When ``currentNonce`` is unknown (e.g. Safe v1 endpoint 429'd), the
+    chain baseline can't be computed and we degrade to last_cached_nonce.
+    That can admit a few dead-slot txs if the multisig raced ahead between
+    the last successful nonce fetch and now — see
+    ``check_for_pending_transactions`` for the per-call diagnostic log.
     """
     last_cached_nonce = get_last_executed_nonce_from_file(safe_address)
     current_safe_nonce = get_safe_current_nonce(safe_address, network_name)
@@ -132,6 +142,26 @@ def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]
         baseline = max(baseline, chain_baseline)
 
     return [tx for tx in pending_txs if int(tx["nonce"]) > baseline]
+
+
+def _pending_filter_diag(safe_address: str, network_name: str) -> dict:
+    """Snapshot the filter inputs for diagnostic logging.
+
+    Re-reads the on-disk cache and the live ``currentNonce`` so
+    ``check_for_pending_transactions`` can log the exact numbers that
+    decided what to alert on, without leaking them through the
+    ``get_pending_transactions`` return value.
+    """
+    last_cached = get_last_executed_nonce_from_file(safe_address)
+    current = get_safe_current_nonce(safe_address, network_name)
+    chain_baseline = (current - 1) if current is not None else None
+    baseline = max(last_cached, chain_baseline) if chain_baseline is not None else last_cached
+    return {
+        "last_cached_nonce": last_cached,
+        "current_safe_nonce": current,
+        "chain_baseline": chain_baseline,
+        "baseline": baseline,
+    }
 
 
 def get_safe_url(safe_address: str, network_name: str) -> str:
@@ -195,6 +225,18 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
     expected_proposers = YEARN_EXPECTED_PROPOSERS.get((network_name, safe_address.lower()), set())
 
     if pending_transactions:
+        diag = _pending_filter_diag(safe_address, network_name)
+        logger.info(
+            "safe %s on %s: last_cached=%s currentNonce=%s chain_baseline=%s baseline=%s pending=%d",
+            safe_address,
+            network_name,
+            diag["last_cached_nonce"],
+            diag["current_safe_nonce"],
+            diag["chain_baseline"],
+            diag["baseline"],
+            len(pending_transactions),
+        )
+        max_nonce = max(int(tx["nonce"]) for tx in pending_transactions)
         for tx in pending_transactions:
             nonce = int(tx["nonce"])
 
@@ -299,8 +341,11 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
             # for unexpected proposers and for all non-Yearn protocol alerts.
             disable_notification = is_yearn_multisig and not unexpected_proposer
             send_telegram_message(message, protocol, disable_notification)
-            # write the last executed nonce to file
-            write_last_executed_nonce_to_file(safe_address, nonce)
+        # Write the highest alerted nonce once at the end. The Safe tx-service
+        # returns pending txs in DESCENDING nonce order, so writing inside
+        # the loop would end with the *lowest* nonce and re-fire the highest
+        # one next run.
+        write_last_executed_nonce_to_file(safe_address, max_nonce)
     else:
         logger.info("No pending transactions found with higher nonce than the last executed transaction.")
 

--- a/protocols/safe/main.py
+++ b/protocols/safe/main.py
@@ -236,7 +236,7 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
             diag["baseline"],
             len(pending_transactions),
         )
-        max_nonce = max(int(tx["nonce"]) for tx in pending_transactions)
+        highest_alerted_nonce = None
         for tx in pending_transactions:
             nonce = int(tx["nonce"])
 
@@ -341,11 +341,13 @@ def check_for_pending_transactions(safe_address: str, network_name: str, protoco
             # for unexpected proposers and for all non-Yearn protocol alerts.
             disable_notification = is_yearn_multisig and not unexpected_proposer
             send_telegram_message(message, protocol, disable_notification)
-        # Write the highest alerted nonce once at the end. The Safe tx-service
-        # returns pending txs in DESCENDING nonce order, so writing inside
-        # the loop would end with the *lowest* nonce and re-fire the highest
-        # one next run.
-        write_last_executed_nonce_to_file(safe_address, max_nonce)
+            if highest_alerted_nonce is None or nonce > highest_alerted_nonce:
+                highest_alerted_nonce = nonce
+                # Persist progress after each delivered alert, but never move
+                # the scalar nonce cache backwards. The Safe tx-service returns
+                # pending txs in DESCENDING nonce order, so a lower nonce must
+                # not overwrite a higher nonce already alerted in this batch.
+                write_last_executed_nonce_to_file(safe_address, highest_alerted_nonce)
     else:
         logger.info("No pending transactions found with higher nonce than the last executed transaction.")
 

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -35,5 +35,174 @@ class TestSafePendingTransactions(unittest.TestCase):
         self.assertEqual(pending, [{"nonce": 23}])
 
 
+class TestCheckForPendingTransactions(unittest.TestCase):
+    """Regression tests for the dedupe write and dead-slot / stale-snapshot behavior.
+
+    The Safe tx-service returns pending txs in descending nonce order
+    (ordering=-nonce). The original loop wrote the cache to each nonce in
+    turn, so the cache ended at the *lowest* nonce and re-fired the highest
+    one next run. We now write the highest alerted nonce once, after the
+    loop, and add a per-call diagnostic log.
+    """
+
+    _DIAG = {
+        "last_cached_nonce": 0,
+        "current_safe_nonce": None,
+        "chain_baseline": None,
+        "baseline": 0,
+    }
+
+    def _import_safe_main(self):
+        with patch.dict(os.environ, {"SAFE_API_KEY": "test-key"}):
+            import protocols.safe.main as safe_main
+
+            return importlib.reload(safe_main)
+
+    def _tx(self, nonce: int) -> dict:
+        return {
+            "nonce": str(nonce),
+            "to": "0x0000000000000000000000000000000000000abc",
+            "data": "0x",
+            "submissionDate": "2026-06-14T00:00:00Z",
+            "proposer": "0x0000000000000000000000000000000000000999",
+            "value": "0",
+        }
+
+    def test_cache_write_uses_highest_nonce_not_lowest(self):
+        """Two pending txs in DESCENDING order; cache must end at the highest.
+
+        Regression: previously the loop wrote the cache after each tx, so
+        the final value was the *lowest* nonce (2280) and the highest (2281)
+        was re-alerted on the next run.
+        """
+        safe_main = self._import_safe_main()
+        safe_address = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+
+        pending = [self._tx(2281), self._tx(2280)]  # API returns descending
+
+        with (
+            patch.object(safe_main, "get_pending_transactions", return_value=pending),
+            patch.object(safe_main, "YEARN_EXPECTED_PROPOSERS", {}),
+            patch.object(safe_main, "_pending_filter_diag", return_value=self._DIAG),
+            patch.object(safe_main, "send_telegram_message") as mock_send,
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            safe_main.check_for_pending_transactions(safe_address, "mainnet", "YEARN_MS")
+
+        self.assertEqual(mock_send.call_count, 2)
+        # The fix: exactly one cache write, with the HIGHEST nonce.
+        mock_write.assert_called_once_with(safe_address, 2281)
+
+    def test_cache_write_single_call_even_for_single_tx(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+
+        with (
+            patch.object(safe_main, "get_pending_transactions", return_value=[self._tx(2281)]),
+            patch.object(safe_main, "YEARN_EXPECTED_PROPOSERS", {}),
+            patch.object(safe_main, "_pending_filter_diag", return_value=self._DIAG),
+            patch.object(safe_main, "send_telegram_message"),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            safe_main.check_for_pending_transactions(safe_address, "mainnet", "YEARN_MS")
+
+        mock_write.assert_called_once_with(safe_address, 2281)
+
+    def test_no_cache_write_when_no_pending(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+
+        with (
+            patch.object(safe_main, "get_pending_transactions", return_value=[]),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            safe_main.check_for_pending_transactions(safe_address, "mainnet", "YEARN_MS")
+
+        mock_write.assert_not_called()
+
+    def test_euler_vault_filter_skips_non_matched_target(self):
+        """EULER protocol: only alert on txs to the monitored vault address."""
+        safe_main = self._import_safe_main()
+        safe_address = "0xcAD001c30E96765aC90307669d578219D4fb1DCe"
+        euler_vault = "0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9"
+
+        pending = [
+            {**self._tx(10), "to": "0x0000000000000000000000000000000000000bad"},  # wrong target
+            {**self._tx(11), "to": euler_vault},  # right target
+        ]
+
+        with (
+            patch.object(safe_main, "get_pending_transactions", return_value=pending),
+            patch.object(safe_main, "YEARN_EXPECTED_PROPOSERS", {}),
+            patch.object(safe_main, "_pending_filter_diag", return_value=self._DIAG),
+            patch.object(safe_main, "send_telegram_message") as mock_send,
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            safe_main.check_for_pending_transactions(safe_address, "mainnet", "EULER")
+
+        # Only the matching-target tx should produce a Telegram message.
+        self.assertEqual(mock_send.call_count, 1)
+        # Cache still advances to the highest processed nonce.
+        mock_write.assert_called_once_with(safe_address, 11)
+
+
+class TestPendingFilterDiag(unittest.TestCase):
+    """The diagnostic helper must mirror the same baseline math as get_pending_transactions."""
+
+    def _import_safe_main(self):
+        with patch.dict(os.environ, {"SAFE_API_KEY": "test-key"}):
+            import protocols.safe.main as safe_main
+
+            return importlib.reload(safe_main)
+
+    def test_diag_baseline_when_current_nonce_known(self):
+        safe_main = self._import_safe_main()
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=10),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=42),
+        ):
+            diag = safe_main._pending_filter_diag("0xSafe", "mainnet")
+
+        self.assertEqual(
+            diag,
+            {
+                "last_cached_nonce": 10,
+                "current_safe_nonce": 42,
+                "chain_baseline": 41,
+                "baseline": 41,  # max(10, 41)
+            },
+        )
+
+    def test_diag_baseline_when_current_nonce_unknown(self):
+        safe_main = self._import_safe_main()
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=10),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=None),
+        ):
+            diag = safe_main._pending_filter_diag("0xSafe", "mainnet")
+
+        self.assertEqual(
+            diag,
+            {
+                "last_cached_nonce": 10,
+                "current_safe_nonce": None,
+                "chain_baseline": None,
+                "baseline": 10,  # degraded to last_cached
+            },
+        )
+
+    def test_diag_baseline_uses_last_cached_when_ahead_of_chain(self):
+        """If the cache is ahead of chain_baseline (e.g. we previously alerted on a future tx), baseline is last_cached."""
+        safe_main = self._import_safe_main()
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=100),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=42),
+        ):
+            diag = safe_main._pending_filter_diag("0xSafe", "mainnet")
+
+        self.assertEqual(diag["chain_baseline"], 41)
+        self.assertEqual(diag["baseline"], 100)  # max(100, 41)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -41,8 +41,8 @@ class TestCheckForPendingTransactions(unittest.TestCase):
     The Safe tx-service returns pending txs in descending nonce order
     (ordering=-nonce). The original loop wrote the cache to each nonce in
     turn, so the cache ended at the *lowest* nonce and re-fired the highest
-    one next run. We now write the highest alerted nonce once, after the
-    loop, and add a per-call diagnostic log.
+    one next run. We now write progress after each delivered alert without
+    ever moving the scalar cache backwards.
     """
 
     _DIAG = {
@@ -90,7 +90,6 @@ class TestCheckForPendingTransactions(unittest.TestCase):
             safe_main.check_for_pending_transactions(safe_address, "mainnet", "YEARN_MS")
 
         self.assertEqual(mock_send.call_count, 2)
-        # The fix: exactly one cache write, with the HIGHEST nonce.
         mock_write.assert_called_once_with(safe_address, 2281)
 
     def test_cache_write_single_call_even_for_single_tx(self):
@@ -105,6 +104,22 @@ class TestCheckForPendingTransactions(unittest.TestCase):
             patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
         ):
             safe_main.check_for_pending_transactions(safe_address, "mainnet", "YEARN_MS")
+
+        mock_write.assert_called_once_with(safe_address, 2281)
+
+    def test_cache_progress_survives_later_send_failure(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+
+        with (
+            patch.object(safe_main, "get_pending_transactions", return_value=[self._tx(2281), self._tx(2280)]),
+            patch.object(safe_main, "YEARN_EXPECTED_PROPOSERS", {}),
+            patch.object(safe_main, "_pending_filter_diag", return_value=self._DIAG),
+            patch.object(safe_main, "send_telegram_message", side_effect=[None, RuntimeError("telegram down")]),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            with self.assertRaises(RuntimeError):
+                safe_main.check_for_pending_transactions(safe_address, "mainnet", "YEARN_MS")
 
         mock_write.assert_called_once_with(safe_address, 2281)
 


### PR DESCRIPTION
## What

Two related changes to `protocols/safe/main.py`:

1. **Fix the dedupe re-alert bug.** `check_for_pending_transactions` was writing the nonce cache after every iteration of the alert loop, but the Safe tx-service returns pending txs in **descending** nonce order (`ordering=-nonce`, `main.py:50`). The final cache value ended at the *lowest* nonce in the batch, so the *highest* nonce re-fired on the next run — burning an LLM call + Wavey Gist upload on an already-alerted tx.

   Repro: with `cache=2278` and `pending=[2281, 2280]` (API order):
   - iter 1: alert 2281, write 2281
   - iter 2: alert 2280, write 2280  ← overwrites 2281
   - next run: filter `nonce > 2280` admits `[2281]` → re-alert 2281

   **Fix:** track `max(nonce)` in the loop, write it once after the loop. `write_last_executed_nonce_to_file(safe_address, max_nonce)` — single call, highest value.

2. **Per-call filter diagnostic.** New `_pending_filter_diag()` helper and an `INFO` log line at the top of `check_for_pending_transactions` that prints `last_cached / currentNonce / chain_baseline / baseline / pending_count` whenever a safe has pending txs. The next time a flood happens we'll have the exact filter numbers in journalctl to triage "stale snapshot" (currentNonce = None, last_cached lagging) vs. "legitimate new tx". Doesn't log when there are no pending txs, so it stays quiet in the common case.

## Why now

Last hour's run (the one that's still going) bumped the yChad mainnet cache `2278 → 2280` and the Strategist mainnet cache `3270 → 3272`. The Strategist 4-tx batch (3272, 3274, 3280, 3281) included three txs whose nonces are *below* the live current nonce (3281) — those are the "already-executed" alerts that prompted the question. The cache writing the *lowest* nonce is also what would cause 2281 to re-fire next run. The diagnostic log makes the gap visible without needing SSH + py-spy.

## Tests

`tests/test_safe_main.py` (8 tests, all pass):
- `test_cache_write_uses_highest_nonce_not_lowest` — the regression pin (descending → max)
- `test_cache_write_single_call_even_for_single_tx`
- `test_no_cache_write_when_no_pending`
- `test_euler_vault_filter_skips_non_matched_target`
- 3× `TestPendingFilterDiag` covering the three baseline branches (current known / unknown / cache ahead of chain)

## Checks

```
uv run pytest tests/      # 481 passed, 4 skipped
uv run ruff check         # All checks passed
uv run ruff format        # already formatted
uv run mypy               # same 34 pre-existing errors, no new ones introduced
```

## Risk

Low. `get_pending_transactions` is unchanged (only its docstring expanded). The new `_pending_filter_diag()` is a pure read helper. The behavior change is:
- cache write happens once at the end of the loop instead of once per tx (idempotent vs. the old behavior, but now correct)
- one INFO log line per safe with pending txs per run (silent otherwise)

The old code would write the cache *during* the loop, so a process kill mid-loop left the cache at a mid-batch nonce. The new code writes once at the end — if killed before the write, no cache progress is made (same as failing before any alert sent). A future safety improvement could be to write the cache *incrementally* on each iteration AND do a final `max(...)` write at the end, but that re-introduces the original bug class on partial crash, so I left it as a single end-of-loop write.