### PR TITLE
fix(safe): never alert executed transactions

### DIFF
--- a/protocols/safe/main.py
+++ b/protocols/safe/main.py
@@ -111,6 +111,16 @@ def get_safe_current_nonce(safe_address: str, network_name: str) -> int | None:
         return None
 
 
+def _is_executed_safe_tx(tx: dict) -> bool:
+    """Return True for tx-service rows that are already executed.
+
+    The API request asks for ``executed=false``, but the monitor treats the
+    response defensively: if an item carries any executed marker, it must never
+    reach the alert path.
+    """
+    return tx.get("isExecuted") is True or bool(tx.get("executionDate")) or bool(tx.get("transactionHash"))
+
+
 def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]:
     """Fetch pending transactions worth alerting on.
 
@@ -119,6 +129,8 @@ def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]
     - Dead-slot: nonce < safe.currentNonce. These remain in the API as
       ``executed=false`` because a competing tx at the same nonce executed
       first, but they will never run themselves.
+    - Executed rows: any tx-service row with executed markers. These must never
+      alert even if the API includes them in an ``executed=false`` response.
 
     The baseline is the higher of (a) the last nonce we already alerted on
     and (b) ``currentNonce - 1`` (the last *executed* nonce, when we could
@@ -141,7 +153,7 @@ def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]
             write_last_executed_nonce_to_file(safe_address, chain_baseline)
         baseline = max(baseline, chain_baseline)
 
-    return [tx for tx in pending_txs if int(tx["nonce"]) > baseline]
+    return [tx for tx in pending_txs if not _is_executed_safe_tx(tx) and int(tx["nonce"]) > baseline]
 
 
 def _pending_filter_diag(safe_address: str, network_name: str) -> dict:

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -34,6 +34,28 @@ class TestSafePendingTransactions(unittest.TestCase):
         mock_write.assert_called_once_with(safe_address, 22)
         self.assertEqual(pending, [{"nonce": 23}])
 
+    def test_executed_rows_are_filtered_even_when_api_returns_them(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xSafe"
+
+        txs = [
+            {"nonce": 30, "isExecuted": True},
+            {"nonce": 31, "executionDate": "2026-06-14T21:00:00Z"},
+            {"nonce": 32, "transactionHash": "0x" + "ab" * 32},
+            {"nonce": 33, "isExecuted": False, "executionDate": None, "transactionHash": None},
+        ]
+
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=0),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=None),
+            patch.object(safe_main, "get_safe_transactions", return_value=txs),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            pending = safe_main.get_pending_transactions(safe_address, "mainnet")
+
+        mock_write.assert_not_called()
+        self.assertEqual(pending, [{"nonce": 33, "isExecuted": False, "executionDate": None, "transactionHash": None}])
+
 
 class TestCheckForPendingTransactions(unittest.TestCase):
     """Regression tests for the dedupe write and dead-slot / stale-snapshot behavior.


### PR DESCRIPTION
## Summary
- defensively filter Safe tx-service rows with executed markers before alerting
- cover isExecuted, executionDate, and transactionHash markers in Safe tests

## Tests
- /srv/monitoring/.venv/bin/python -m pytest tests/test_safe_main.py