### PR TITLE
fix(automation): force sync checkout to origin main

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -40,7 +40,7 @@ uv run python -m automation run daily --dry-run
        cache-file: /srv/cache/my-protocol.json
    ```
 3. `uv run python -m automation render-crontab` — confirm the line you expect appears.
-4. Merge to `main`, then on the VPS `git pull` and `sudo systemctl restart yearn-monitor` to
+4. Merge to `main`, then on the VPS sync to `origin/main` and restart `monitoring` to
    re-render the crontab (see [deploy/runbook.md](../deploy/runbook.md)).
 
 ## Profile shape

--- a/automation/git_sync.py
+++ b/automation/git_sync.py
@@ -1,14 +1,15 @@
-"""Fast-forward the live VPS checkout to origin before a profile runs.
+"""Force the live VPS checkout to match origin/main before a profile runs.
 
-Deliberately minimal: a single `git pull --ff-only` wrapper, no locking and no
-divergence handling. The monitoring app is pure read-only — it never commits or
-writes anything back into the checkout — so there is nothing for a pull to race
-against. `--ff-only` refuses to merge or clobber, and the worst case of a failed
-pull is that we run slightly older read-only code, which is harmless. Callers
+Deliberately minimal: fetch ``origin/main`` and hard-reset the checkout to it.
+The monitoring app is pure read-only — it never commits or writes anything back
+into the checkout — so local tracked-file drift is disposable. If an operator
+hot-edits a tracked file or the local branch diverges, the next sync discards it
+in favor of the reviewed remote ``main`` branch. The worst case of a failed sync
+is that we run slightly older read-only code, which is harmless. Callers
 therefore log and carry on rather than skipping the run.
 
 Anchored on the most frequent profile (`multisig`, every 10 min via
-`sync_before_run` in jobs.yaml): one pull there keeps the whole tree current for
+`sync_before_run` in jobs.yaml): one sync there keeps the whole tree current for
 every other profile, since supercronic re-spawns each profile fresh against
 whatever is on disk.
 """
@@ -25,36 +26,46 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class SyncResult:
-    """Outcome of a `git pull --ff-only`."""
+    """Outcome of a forced sync to origin/main."""
 
     ok: bool
     output: str
 
 
-def pull_ff_only(repo_root: Path) -> SyncResult:
-    """Fast-forward `repo_root` to its upstream branch.
+def sync_to_remote_main(repo_root: Path) -> SyncResult:
+    """Force `repo_root` to match origin/main.
 
     Args:
         repo_root: Path to the git checkout to update.
 
     Returns:
         SyncResult with `ok` False when git is missing, the path is not a
-        checkout, or the pull is non-fast-forward / fails. Never raises.
+        checkout, or fetch/reset fails. Never raises.
     """
     if not (repo_root / ".git").exists():
         return SyncResult(ok=False, output=f"{repo_root} is not a git checkout")
 
     try:
-        completed = subprocess.run(
-            ["git", "-C", str(repo_root), "pull", "--ff-only", "--quiet"],
+        fetch = subprocess.run(
+            ["git", "-C", str(repo_root), "fetch", "--quiet", "origin", "main"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if fetch.returncode != 0:
+            output = (fetch.stdout + fetch.stderr).strip()
+            return SyncResult(ok=False, output=output or f"fetch exited {fetch.returncode}")
+
+        reset = subprocess.run(
+            ["git", "-C", str(repo_root), "reset", "--hard", "--quiet", "origin/main"],
             capture_output=True,
             text=True,
             check=False,
         )
     except OSError as exc:
-        return SyncResult(ok=False, output=f"git pull failed to spawn: {exc}")
+        return SyncResult(ok=False, output=f"git sync failed to spawn: {exc}")
 
-    output = (completed.stdout + completed.stderr).strip()
-    if completed.returncode != 0:
-        return SyncResult(ok=False, output=output or f"exit {completed.returncode}")
+    output = (reset.stdout + reset.stderr).strip()
+    if reset.returncode != 0:
+        return SyncResult(ok=False, output=output or f"reset exited {reset.returncode}")
     return SyncResult(ok=True, output=output)

--- a/automation/jobs.yaml
+++ b/automation/jobs.yaml
@@ -6,8 +6,8 @@
 #     crontab on start (see deploy/runbook.md).
 #
 # Adding or removing a script: edit the relevant profile's `tasks:` and merge to main. The
-# multisig profile's pre-run `git pull` (sync_before_run, below) lands it on the box within
-# ~10 min — no restart needed. Only a `cron:` cadence change requires `git pull` +
+# multisig profile's pre-run sync (sync_before_run, below) lands it on the box within
+# ~10 min — no restart needed. Only a `cron:` cadence change requires sync +
 # `sudo systemctl restart monitoring` to re-render the crontab (see deploy/runbook.md).
 #
 # Each task invokes one script. CLI flags go under `args:` as `key: value` and are emitted as
@@ -75,10 +75,11 @@ profiles:
     # No env override: nonces land in the default nonces.txt under $CACHE_DIR.
     #
     # This is the box's code-sync heartbeat. Being the most frequent profile, a
-    # `git pull --ff-only` before it (sync_before_run) keeps the whole checkout
-    # current at a 10-min cadence — every other profile re-spawns fresh against
-    # whatever is on disk, so they ride along for free. Best-effort: a failed
-    # pull is logged and the checks run anyway (see automation/git_sync.py).
+    # forced sync to origin/main before it (sync_before_run) keeps the whole
+    # checkout current at a 10-min cadence — every other profile re-spawns fresh
+    # against whatever is on disk, so they ride along for free. Best-effort: a
+    # failed sync is logged and the checks run anyway (see automation/git_sync.py).
+    # Tracked local edits are intentionally discarded in favor of reviewed main.
     # NOTE: this lands new *code/config* only. Cron-cadence changes in this file
     # and dependency changes (pyproject.toml/uv.lock) still need a manual
     # `uv sync --frozen --extra ai` + `systemctl restart monitoring`.

--- a/automation/runner.py
+++ b/automation/runner.py
@@ -163,13 +163,13 @@ def run_profile(
 
 
 def _sync_repo(repo_root: Path) -> None:
-    """Fast-forward the checkout to origin before running the profile's tasks.
+    """Force the checkout to origin/main before running the profile's tasks.
 
-    Best-effort: a failed pull is logged but never blocks the run — these are
+    Best-effort: a failed sync is logged but never blocks the run — these are
     read-only checks, so running slightly older code is harmless, and we never
     want a transient git hiccup to silence an alert. See `automation.git_sync`.
     """
-    result = git_sync.pull_ff_only(repo_root)
+    result = git_sync.sync_to_remote_main(repo_root)
     if result.ok:
         logger.info("pre-run git sync: %s", result.output or "already up to date")
     else:

--- a/deploy/runbook.md
+++ b/deploy/runbook.md
@@ -77,18 +77,21 @@ Contributors merge to `main` through PRs; nobody normally SSHes in to ship code.
 Two things move `main` onto the box, split on *"does the change need the
 scheduler restarted to take effect?"*
 
-**Auto-sync (no restart, the common case).** The `multisig` profile runs
-`git pull --ff-only` before its tasks every 10 minutes (`sync_before_run: true`
-in `jobs.yaml`). Since supercronic re-spawns every profile fresh against the
-on-disk tree, that one pull keeps the whole checkout current for *all* profiles
-within ~10 minutes — every other profile rides along for free. The pull is
-best-effort: a failure is logged (`journalctl -u monitoring | grep 'pre-run git
-sync'`) and the multisig checks run against the existing checkout anyway, so a
-git hiccup never silences an alert. This covers **scripts, config modules, data,
-and `jobs.yaml` task bodies** — anything read fresh by a subprocess.
+**Auto-sync (no restart, the common case).** The `multisig` profile fetches
+`origin main` and runs `git reset --hard origin/main` before its tasks every 10
+minutes (`sync_before_run: true` in `jobs.yaml`). Since supercronic re-spawns
+every profile fresh against the on-disk tree, that one sync keeps the whole
+checkout current for *all* profiles within ~10 minutes — every other profile
+rides along for free. Tracked local edits are intentionally discarded in favor
+of reviewed `main`, so the VPS does not get stuck on a divergent local branch or
+operator hotfix. The sync is best-effort: a failure is logged (`journalctl -u
+monitoring | grep 'pre-run git sync'`) and the multisig checks run against the
+existing checkout anyway, so a git hiccup never silences an alert. This covers
+**scripts, config modules, data, and `jobs.yaml` task bodies** — anything read
+fresh by a subprocess.
 
 So for the common case — a script tweak, a new task in a profile — **merge the
-PR and the next ~10-min multisig tick pulls it in; no SSH needed.**
+PR and the next ~10-min multisig tick syncs it in; no SSH needed.**
 
 **Manual restart (cadence + deps).** Two kinds of change land on disk via the
 auto-sync but stay inert until a restart, because they're read once at scheduler
@@ -102,7 +105,7 @@ For those, after the PR merges:
 
 ```sh
 cd /srv/monitoring
-git pull --ff-only            # or just let the next multisig tick land it
+git fetch origin main && git reset --hard origin/main  # or let the next multisig tick land it
 uv sync --frozen --extra ai   # only if pyproject.toml / uv.lock changed (--extra ai: openai client for the AI explainer)
 sudo systemctl restart monitoring   # re-renders the crontab and re-points supercronic at the tree
 ```
@@ -215,7 +218,8 @@ skipped, not queued) — the others keep ticking.
 - systemd unit: `/etc/systemd/system/monitoring.service`.
 - Rendered crontab: `/tmp/crontab` (per-service `PrivateTmp`; regenerated on
   every start).
-- Code sync: no separate unit — the `multisig` profile's pre-run `git pull
-  --ff-only` (`sync_before_run` in `jobs.yaml`) every 10 min. The unit grants
+- Code sync: no separate unit — the `multisig` profile's pre-run `git fetch
+  origin main` + `git reset --hard origin/main` (`sync_before_run` in
+  `jobs.yaml`) every 10 min. The unit grants
   the repo write access via `ReadWritePaths=/srv/cache /srv/monitoring` so the
-  pull can update `.git/` under `ProtectSystem=strict`.
+  sync can update `.git/` under `ProtectSystem=strict`.

--- a/deploy/systemd/monitoring.service
+++ b/deploy/systemd/monitoring.service
@@ -72,10 +72,11 @@ StartLimitBurst=5
 
 # Hardening — cheap wins now that there's no container boundary. __CACHE_DIR__ is
 # the scripts' state path (dedupe caches, nonces). The repo tree is also writable
-# because the multisig profile fast-forwards the checkout in-process before each
-# run (sync_before_run in jobs.yaml → git pull --ff-only, which writes .git/ and
-# the working tree); ProtectSystem=strict would otherwise make it read-only and
-# fail the pull. The venv and the rest of the system stay read-only.
+# because the multisig profile syncs the checkout in-process before each run
+# (sync_before_run in jobs.yaml → git fetch + git reset --hard origin/main,
+# which writes .git/ and the working tree); ProtectSystem=strict would otherwise
+# make it read-only and fail the sync. The venv and the rest of the system stay
+# read-only.
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict

--- a/tests/test_automation_git_sync.py
+++ b/tests/test_automation_git_sync.py
@@ -1,0 +1,73 @@
+"""Tests for automation/git_sync.py."""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from automation.git_sync import sync_to_remote_main
+
+
+class _Result:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestSyncToRemoteMain(unittest.TestCase):
+    def test_requires_git_checkout(self):
+        with TemporaryDirectory() as d:
+            result = sync_to_remote_main(Path(d))
+
+        self.assertFalse(result.ok)
+        self.assertIn("not a git checkout", result.output)
+
+    def test_fetches_then_hard_resets_origin_main(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / ".git").mkdir()
+
+            with patch("automation.git_sync.subprocess.run", side_effect=[_Result(), _Result()]) as mock_run:
+                result = sync_to_remote_main(repo)
+
+        self.assertTrue(result.ok)
+        self.assertEqual(
+            [call.args[0] for call in mock_run.call_args_list],
+            [
+                ["git", "-C", str(repo), "fetch", "--quiet", "origin", "main"],
+                ["git", "-C", str(repo), "reset", "--hard", "--quiet", "origin/main"],
+            ],
+        )
+
+    def test_fetch_failure_stops_before_reset(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / ".git").mkdir()
+
+            with patch(
+                "automation.git_sync.subprocess.run", return_value=_Result(1, stderr="network down")
+            ) as mock_run:
+                result = sync_to_remote_main(repo)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(mock_run.call_count, 1)
+        self.assertIn("network down", result.output)
+
+    def test_reset_failure_is_reported(self):
+        with TemporaryDirectory() as d:
+            repo = Path(d)
+            (repo / ".git").mkdir()
+
+            with patch(
+                "automation.git_sync.subprocess.run",
+                side_effect=[_Result(), _Result(128, stderr="cannot lock ref")],
+            ):
+                result = sync_to_remote_main(repo)
+
+        self.assertFalse(result.ok)
+        self.assertIn("cannot lock ref", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_automation_runner.py
+++ b/tests/test_automation_runner.py
@@ -9,8 +9,14 @@ from automation.config import Profile, Task
 from automation.runner import ProfileResult, TaskResult, build_argv, run_profile
 
 
-def _profile(tasks: list[Task], env: dict[str, str] | None = None) -> Profile:
-    return Profile(name="hourly", cron="26 * * * *", tasks=tasks, env=env or {})
+def _profile(tasks: list[Task], env: dict[str, str] | None = None, sync_before_run: bool = False) -> Profile:
+    return Profile(
+        name="hourly",
+        cron="26 * * * *",
+        tasks=tasks,
+        env=env or {},
+        sync_before_run=sync_before_run,
+    )
 
 
 class TestBuildArgv(unittest.TestCase):
@@ -62,6 +68,20 @@ class TestRunProfileSuccess(unittest.TestCase):
         self.assertEqual(kwargs["cwd"], Path("/srv/repo"))
         self.assertEqual(kwargs["env"]["CACHE_FILENAME"], "/srv/cache/foo.txt")
         self.assertFalse(kwargs["check"])
+
+    def test_sync_before_run_forces_remote_main_sync(self):
+        profile = _profile([Task(name="x", script="x.py")], sync_before_run=True)
+
+        class _Result:
+            returncode = 0
+
+        with (
+            patch("automation.runner.git_sync.sync_to_remote_main") as mock_sync,
+            patch("automation.runner.subprocess.run", return_value=_Result()),
+        ):
+            run_profile(profile, repo_root=Path("/srv/repo"), dry_run=False, send_digest=False)
+
+        mock_sync.assert_called_once_with(Path("/srv/repo"))
 
 
 class TestRunProfileContinuesOnFailure(unittest.TestCase):


### PR DESCRIPTION
## Summary
- replace pre-run git pull --ff-only with fetch origin main + reset --hard origin/main
- keep sync best-effort so monitoring continues if GitHub is temporarily unavailable
- document that tracked local edits on the VPS are discarded in favor of reviewed main

## Tests
- /srv/monitoring/.venv/bin/python -m pytest tests/test_automation_git_sync.py tests/test_automation_runner.py tests/test_automation_render.py tests/test_automation_config.py