### PR TITLE
fix(safe): skip alerts when current nonce is unavailable

### DIFF
--- a/protocols/safe/main.py
+++ b/protocols/safe/main.py
@@ -136,22 +136,28 @@ def get_pending_transactions(safe_address: str, network_name: str) -> list[dict]
     and (b) ``currentNonce - 1`` (the last *executed* nonce, when we could
     fetch it). A tx is eligible iff ``nonce > baseline``.
 
-    When ``currentNonce`` is unknown (e.g. Safe v1 endpoint 429'd), the
-    chain baseline can't be computed and we degrade to last_cached_nonce.
-    That can admit a few dead-slot txs if the multisig raced ahead between
-    the last successful nonce fetch and now — see
-    ``check_for_pending_transactions`` for the per-call diagnostic log.
+    When ``currentNonce`` is unknown (e.g. Safe v1 endpoint 429'd), the chain
+    baseline can't be computed safely, so we fail closed and skip alerts for
+    this safe until the next run. That prevents dead-slot txs from alerting as
+    queued after a competing tx at the same nonce has already executed.
     """
     last_cached_nonce = get_last_executed_nonce_from_file(safe_address)
     current_safe_nonce = get_safe_current_nonce(safe_address, network_name)
     pending_txs = get_safe_transactions(safe_address, network_name, executed=False)
 
+    if current_safe_nonce is None:
+        logger.warning(
+            "Skipping pending tx alerts for %s on %s because currentNonce could not be fetched",
+            safe_address,
+            network_name,
+        )
+        return []
+
     baseline = last_cached_nonce
-    if current_safe_nonce is not None:
-        chain_baseline = current_safe_nonce - 1
-        if chain_baseline > last_cached_nonce:
-            write_last_executed_nonce_to_file(safe_address, chain_baseline)
-        baseline = max(baseline, chain_baseline)
+    chain_baseline = current_safe_nonce - 1
+    if chain_baseline > last_cached_nonce:
+        write_last_executed_nonce_to_file(safe_address, chain_baseline)
+    baseline = max(baseline, chain_baseline)
 
     return [tx for tx in pending_txs if not _is_executed_safe_tx(tx) and int(tx["nonce"]) > baseline]
 

--- a/tests/test_safe_main.py
+++ b/tests/test_safe_main.py
@@ -47,14 +47,56 @@ class TestSafePendingTransactions(unittest.TestCase):
 
         with (
             patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=0),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=30),
+            patch.object(safe_main, "get_safe_transactions", return_value=txs),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            pending = safe_main.get_pending_transactions(safe_address, "mainnet")
+
+        mock_write.assert_called_once_with(safe_address, 29)
+        self.assertEqual(pending, [{"nonce": 33, "isExecuted": False, "executionDate": None, "transactionHash": None}])
+
+    def test_current_nonce_unknown_fails_closed(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xSafe"
+
+        txs = [
+            {"nonce": 3274, "isExecuted": False, "executionDate": None, "transactionHash": None},
+            {"nonce": 3280, "isExecuted": False, "executionDate": None, "transactionHash": None},
+        ]
+
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=0),
             patch.object(safe_main, "get_safe_current_nonce", return_value=None),
             patch.object(safe_main, "get_safe_transactions", return_value=txs),
             patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
         ):
             pending = safe_main.get_pending_transactions(safe_address, "mainnet")
 
+        self.assertEqual(pending, [])
         mock_write.assert_not_called()
-        self.assertEqual(pending, [{"nonce": 33, "isExecuted": False, "executionDate": None, "transactionHash": None}])
+
+    def test_dead_slot_rows_below_current_nonce_are_filtered(self):
+        safe_main = self._import_safe_main()
+        safe_address = "0xSafe"
+
+        txs = [
+            {"nonce": 3280, "isExecuted": False, "executionDate": None, "transactionHash": None},
+            {"nonce": 3282, "isExecuted": False, "executionDate": None, "transactionHash": None},
+        ]
+
+        with (
+            patch.object(safe_main, "get_last_executed_nonce_from_file", return_value=0),
+            patch.object(safe_main, "get_safe_current_nonce", return_value=3282),
+            patch.object(safe_main, "get_safe_transactions", return_value=txs),
+            patch.object(safe_main, "write_last_executed_nonce_to_file") as mock_write,
+        ):
+            pending = safe_main.get_pending_transactions(safe_address, "mainnet")
+
+        mock_write.assert_called_once_with(safe_address, 3281)
+        self.assertEqual(
+            pending, [{"nonce": 3282, "isExecuted": False, "executionDate": None, "transactionHash": None}]
+        )
 
 
 class TestCheckForPendingTransactions(unittest.TestCase):


### PR DESCRIPTION
## Summary
- fail closed when Safe currentNonce cannot be fetched
- prevents stale dead-slot tx-service rows from alerting as queued
- add tests for currentNonce failure and dead-slot filtering below currentNonce

## Root cause
Safe tx-service can keep dead-slot rows in executed=false. Nonce 3274 for brain.ychad.eth is one of those rows: isExecuted=false, no executionDate, no transactionHash, but Safe currentNonce is 3282, so it cannot execute. If currentNonce lookup fails, the old fallback used only the cache baseline and could admit these stale rows.

## Tests
- /srv/monitoring/.venv/bin/python -m pytest tests/test_safe_main.py
- /srv/monitoring/.venv/bin/python -m ruff check protocols/safe/main.py tests/test_safe_main.py
- /srv/monitoring/.venv/bin/python -m ruff format --check protocols/safe/main.py tests/test_safe_main.py