### PR TITLE
fix: prevent duplicate log output via propagate=False

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -16,6 +16,7 @@ def get_logger(name: str) -> logging.Logger:
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s"))
         logger.addHandler(handler)
+        logger.propagate = False
         level = os.getenv("LOG_LEVEL", "INFO").upper()
         logger.setLevel(getattr(logging, level, logging.INFO))
     return logger


### PR DESCRIPTION
## Problem
`morpho.markets_v2` (and any other child logger whose parent also uses `utils.logger.get_logger`) prints every log line twice.

## Root cause
`get_logger` attaches a `StreamHandler` to each named logger but leaves `propagate = True`. When a child logger (e.g. `morpho.markets_v2`) imports a module that creates a parent logger (e.g. `morpho` from `protocols/morpho/markets.py`), the same record is emitted by both handlers.

## Fix
Set `logger.propagate = False` inside `get_logger` when we install our own handler, so each record is only emitted once.

## Verification
Ran `uv run protocols/morpho/markets_v2.py` before and after; duplicate lines are gone.