### PR TITLE
fix: stop timelock alert re-send loop from malformed Markdown

### DIFF
--- a/protocols/timelock/timelock_alerts.py
+++ b/protocols/timelock/timelock_alerts.py
@@ -366,6 +366,36 @@ def _get_ai_explanation(events: list[dict], timelock_info: TimelockConfig, chain
         return None
 
 
+def _truncate_call_lines(call_lines: list[str], budget: int) -> str:
+    """Join ``call_lines`` to fit within ``budget`` chars, dropping whole trailing lines.
+
+    Slicing the joined text mid-line can sever a Markdown entity — e.g. cut an
+    opening backtick in a `signature` before its closing one — which Telegram
+    rejects with a 400 "can't parse entities". A failed send then blocks the
+    caller's dedupe cursor and wedges the monitor into a re-send loop. Dropping
+    whole lines keeps every entity balanced.
+    """
+    marker = "… (truncated)"
+    kept: list[str] = []
+    used = 0
+    for line in call_lines:
+        added = len(line) + (1 if kept else 0)  # +1 for the joining newline
+        if used + added > budget:
+            break
+        kept.append(line)
+        used += added
+
+    if len(kept) == len(call_lines):
+        return "\n".join(kept)
+
+    # Make room for the truncation marker by dropping more whole lines if needed.
+    while kept and used + len(marker) + 1 > budget:
+        dropped = kept.pop()
+        used -= len(dropped) + (1 if kept else 0)
+    kept.append(marker)
+    return "\n".join(kept)
+
+
 def build_alert_message(events: list[dict], timelock_info: TimelockConfig) -> str:
     """Build a Telegram alert message for a group of TimelockEvent events (same operationId).
 
@@ -452,7 +482,7 @@ def build_alert_message(events: list[dict], timelock_info: TimelockConfig) -> st
     if budget > 0:
         call_text = "\n".join(call_lines)
         if len(call_text) > budget:
-            call_text = call_text[: budget - 3] + "..."
+            call_text = _truncate_call_lines(call_lines, budget)
     else:
         call_text = ""
 

--- a/tests/test_alert_capture.py
+++ b/tests/test_alert_capture.py
@@ -84,6 +84,51 @@ def test_telegram_failure_marks_failed_and_reraises(monkeypatch, tmp_path):
     assert row["delivery_error"] == "bad"
 
 
+def test_parse_entities_error_retries_as_plain_text(monkeypatch, tmp_path):
+    """A 400 'can't parse entities' must fall back to a plain-text resend.
+
+    Without this, a malformed-Markdown alert can never deliver, and monitors that
+    gate their dedupe cursor on delivery re-send the whole batch every run.
+    """
+    _use_cache_dir(monkeypatch, tmp_path)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_DEFAULT", "token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID_AAVE", "chat")
+
+    parse_error = TelegramError("Failed to send telegram message: 400 ... can't parse entities: ...")
+
+    def fake_post(bot_token, chat_id, message, plain_text, disable_notification, topic_id=None):
+        if not plain_text:
+            raise parse_error  # Markdown attempt fails
+
+    with patch("utils.telegram._post_message", side_effect=fake_post) as post:
+        send_telegram_message("`broken", "aave")
+
+    # First call Markdown (raises), second call plain text (succeeds).
+    assert post.call_count == 2
+    assert post.call_args_list[0].args[3] is False
+    assert post.call_args_list[1].args[3] is True
+    assert store.query_alerts()[0]["delivery_status"] == "delivered"
+
+
+def test_parse_entities_error_plain_retry_failure_marks_failed(monkeypatch, tmp_path):
+    """If even the plain-text retry fails, the alert is marked failed and re-raises."""
+    _use_cache_dir(monkeypatch, tmp_path)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN_DEFAULT", "token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID_AAVE", "chat")
+
+    def fake_post(bot_token, chat_id, message, plain_text, disable_notification, topic_id=None):
+        if not plain_text:
+            raise TelegramError("can't parse entities")
+        raise TelegramError("chat not found")
+
+    with patch("utils.telegram._post_message", side_effect=fake_post):
+        with pytest.raises(TelegramError):
+            send_telegram_message("`broken", "aave")
+    row = store.query_alerts()[0]
+    assert row["delivery_status"] == "failed"
+    assert "chat not found" in row["delivery_error"]
+
+
 def test_missing_credentials_and_debug_are_recorded(monkeypatch, tmp_path):
     _use_cache_dir(monkeypatch, tmp_path)
     send_telegram_message("missing", "aave")

--- a/tests/test_timelock_alerts.py
+++ b/tests/test_timelock_alerts.py
@@ -71,7 +71,31 @@ class TestBuildAlertMessageTruncation(unittest.TestCase):
         ]
         msg = build_alert_message(events, TIMELOCK_INFO)
         self.assertLessEqual(len(msg), MAX_MESSAGE_LENGTH)
-        self.assertIn("...", msg)
+        self.assertIn("truncated", msg)
+
+    @patch("protocols.timelock.timelock_alerts._get_ai_explanation", return_value=None)
+    def test_truncation_keeps_markdown_entities_balanced(self, _mock_ai: object) -> None:
+        """Truncating call details must not sever a `signature` mid-entity.
+
+        Regression: slicing the joined text mid-line left an unclosed backtick,
+        which Telegram rejected with 400 "can't parse entities", freezing the
+        dedupe cursor and re-sending every event hourly.
+        """
+        events = [
+            _make_event(
+                index=i,
+                target=f"0x{i:040x}",
+                data="0x" + "ab" * 4,
+                signature="update_max_debt_for_strategy(address,uint256)",
+            )
+            for i in range(60)
+        ]
+        msg = build_alert_message(events, TIMELOCK_INFO)
+
+        self.assertLessEqual(len(msg), MAX_MESSAGE_LENGTH)
+        # Backticks (code spans) and link brackets must come in balanced pairs.
+        self.assertEqual(msg.count("`") % 2, 0, "unbalanced backticks would break Telegram Markdown")
+        self.assertEqual(msg.count("["), msg.count("]"), "unbalanced link brackets")
 
     @patch("protocols.timelock.timelock_alerts.format_explanation_line")
     @patch("protocols.timelock.timelock_alerts._get_ai_explanation")
@@ -100,7 +124,7 @@ class TestBuildAlertMessageTruncation(unittest.TestCase):
         # Footer (tx link) must be present
         self.assertIn("Tx:", msg)
         # Call details should be truncated
-        self.assertIn("...", msg)
+        self.assertIn("truncated", msg)
 
     @patch("protocols.timelock.timelock_alerts.format_explanation_line")
     @patch("protocols.timelock.timelock_alerts._get_ai_explanation")

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -50,6 +50,17 @@ class TelegramError(Exception):
     pass
 
 
+def _is_parse_entities_error(exc: TelegramError) -> bool:
+    """Return True if a send failed because Telegram couldn't parse Markdown entities.
+
+    Telegram returns 400 "can't parse entities" when a message contains an
+    unbalanced formatting token (e.g. a truncated `code` span or [link]). Such a
+    message can never be delivered as-is, so callers should retry it as plain text
+    rather than fail permanently.
+    """
+    return "can't parse entities" in str(exc).lower()
+
+
 def _post_message(
     bot_token: str,
     chat_id: str,
@@ -231,6 +242,20 @@ def send_telegram_message(
     try:
         _post_message(bot_token, chat_id, message, plain_text, disable_notification, topic_id)
     except TelegramError as exc:
+        # A malformed-Markdown message (e.g. a truncated `code`/[link] entity)
+        # triggers a 400 "can't parse entities" and can never be delivered as-is.
+        # Callers that gate their dedupe cursor on delivery (e.g. timelock_alerts)
+        # would then re-send the whole batch every run forever. Retry once as plain
+        # text so the alert still lands and the cursor can advance.
+        if not plain_text and _is_parse_entities_error(exc):
+            logger.warning("Markdown parse error from Telegram; retrying as plain text for %s", protocol)
+            try:
+                _post_message(bot_token, chat_id, message, True, disable_notification, topic_id)
+            except TelegramError as retry_exc:
+                _update_alert_delivery_safe(alert_id, status="failed", error=str(retry_exc))
+                raise
+            _update_alert_delivery_safe(alert_id, status="delivered", delivered_at=store.utc_now_iso())
+            return
         _update_alert_delivery_safe(alert_id, status="failed", error=str(exc))
         raise
     _update_alert_delivery_safe(alert_id, status="delivered", delivered_at=store.utc_now_iso())


### PR DESCRIPTION
## Problem

Old, already-reported timelock operations (e.g. an Optimism `updateDelay(604800)` no-op) were being re-sent to Telegram every hour.

## Root cause

1. A large batch Yearn TimelockController operation (10× `add_strategy` + `update_max_debt_for_strategy`) produced an alert message exceeding Telegram's 4096-char limit.
2. `build_alert_message` truncated the call-detail text with a blind `call_text[: budget - 3] + "..."` slice. This cut a `` `signature` `` line mid-token, leaving an **opening backtick with no closing one** (odd backtick count).
3. Telegram rejected the message: `400 Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 3593`.
4. `process_events` only advances the `TIMELOCK_LAST_TS` dedupe cursor when **every** chunk sends successfully (`all_sent`). The poison-pill chunk froze the cursor at `2026-06-17 14:08:35`.
5. Every hourly run then re-fetched and re-sent *all* events past the frozen timestamp — re-delivering the well-formed ones (the no-op the user saw) while the malformed one failed again. Permanent loop.

Evidence from `/srv/cache/monitoring.db`: cursor stuck 7 days; `alert_events` id 102 `failed` with the byte-3593 parse error, id 103 `delivered` (the Optimism no-op header matches the reported alert exactly).

## Fix

- **Safe truncation** — `_truncate_call_lines` drops whole call lines (and appends a `… (truncated)` marker) instead of slicing mid-line, so every Markdown entity stays balanced.
- **Plain-text fallback** — on a 400 "can't parse entities", `send_telegram_message` retries once without `parse_mode`, so a malformed message still lands and the cursor can advance instead of wedging the monitor. This protects **every** protocol, not just timelock.

## Tests

- `test_truncation_keeps_markdown_entities_balanced` — over-budget batch yields balanced backticks/brackets.
- `test_parse_entities_error_retries_as_plain_text` — 400 parse error falls back to a plain-text resend and is marked delivered.
- `test_parse_entities_error_plain_retry_failure_marks_failed` — a failing retry is marked failed and re-raises.
- Updated existing truncation tests for the new marker.

All 19 tests in the two suites pass; `ruff format`/`ruff check` clean.

## Follow-up (not in this PR)

The live cursor is still frozen at June 17. Once this merges (or sooner), advancing `TIMELOCK_LAST_TS` in `/srv/cache/monitoring.db` past the stuck batch will stop the ongoing hourly re-sends. Happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)