### PR TITLE
fix(pegs): correct EIP-55 checksum for WBTC/BTC Chainlink feed

### DIFF
--- a/utils/pegged_assets.py
+++ b/utils/pegged_assets.py
@@ -247,7 +247,7 @@ PEGGED_ASSETS: list[PeggedAsset] = [
         peg=PegTarget.BTC,
         depeg_pct=Decimal("0.02"),
         chainlink_feed=ChainlinkFeed(
-            "0xfdFD9C85aD200c506Cf9e21F1FD8dD01932FBB23", _STABLE_HEARTBEAT, "WBTC/BTC", quote=PegTarget.BTC
+            "0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23", _STABLE_HEARTBEAT, "WBTC/BTC", quote=PegTarget.BTC
         ),
         downside_only=True,  # only a drop below BTC is a risk
     ),


### PR DESCRIPTION
## Problem

The peg monitor crashed on startup:

```
[pegs] 🚨 __main__ crashed: InvalidAddress: ('Address has an invalid EIP-55 checksum. After looking up the address from the original source, try again.', '0xfdFD9C85aD200c506Cf9e21F1FD8dD01932FBB23')
```

The WBTC/BTC Chainlink aggregator address in `utils/pegged_assets.py` had an invalid EIP-55 checksum. When `utils/chainlink.py` passes it to web3's `get_contract`, web3 validates the checksum and raises `InvalidAddress`, crashing the run.

## Fix

Corrected the checksum casing — the `D` before `01932` should be lowercase `d`:

- before: `0xfdFD9C85aD200c506Cf9e21F1FD8dD01932FBB23`
- after:  `0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23`

This is the same address (Chainlink WBTC/BTC feed on Ethereum mainnet), just correctly checksummed.

## Verification

Audited all `ChainlinkFeed` addresses in `pegged_assets.py` against `Web3.to_checksum_address` — all now pass. (The lowercase `cUSD` `defillama_key` is intentional: DefiLlama keys are not web3-checksum-validated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)