### PR TITLE
Refactor USTB to shared Chainlink reader

### DIFF
--- a/protocols/ustb/main.py
+++ b/protocols/ustb/main.py
@@ -15,6 +15,7 @@ Run hourly via GitHub Actions.
 from utils.abi import load_abi
 from utils.alert import Alert, AlertSeverity, send_alert
 from utils.cache import cache_path, get_last_value_for_key_from_file, write_last_value_to_file
+from utils.chainlink import FeedReading, read_feeds, scale_price
 from utils.chains import Chain
 from utils.formatting import format_usd
 from utils.logger import get_logger
@@ -48,10 +49,9 @@ CACHE_KEY_CHAINLINK_NAV = "ustb_chainlink_nav"
 # ABIs
 # ---------------------------------------------------------------------------
 ABI_ORACLE = load_abi("protocols/ustb/abi/SuperstateOracle.json")
-ABI_CHAINLINK = load_abi("common-abi/ChainlinkAggregator.json")
 ABI_ERC20 = load_abi("common-abi/ERC20.json")
 
-USTB_DECIMALS = 6
+USTB_DECIMALS: int = 6
 
 
 def main() -> None:
@@ -59,30 +59,25 @@ def main() -> None:
     client = ChainManager.get_client(Chain.MAINNET)
 
     oracle = client.eth.contract(address=CONTINUOUS_ORACLE, abi=ABI_ORACLE)
-    chainlink = client.eth.contract(address=CHAINLINK_ORACLE, abi=ABI_CHAINLINK)
     ustb = client.eth.contract(address=USTB_TOKEN, abi=ABI_ERC20)
+    chainlink_reading = read_feeds(client, [CHAINLINK_ORACLE])[CHAINLINK_ORACLE]
 
     # --- Batch 1: all independent reads ------------------------------------------------
     with client.batch_requests() as batch:
         batch.add(oracle.functions.latestRoundData())
         batch.add(oracle.functions.decimals())
-        batch.add(chainlink.functions.latestRoundData())
-        batch.add(chainlink.functions.decimals())
         batch.add(ustb.functions.totalSupply())
         responses = client.execute_batch(batch)
 
     oracle_round_data = responses[0]
     oracle_decimals = int(responses[1])
-    chainlink_round_data = responses[2]
-    chainlink_decimals = int(responses[3])
-    total_supply_raw = int(responses[4])
+    total_supply_raw = int(responses[2])
 
     oracle_round_id = int(oracle_round_data[0])
     oracle_answer = int(oracle_round_data[1])
-    chainlink_answer = int(chainlink_round_data[1])
 
-    oracle_price = oracle_answer / (10**oracle_decimals)
-    chainlink_price = chainlink_answer / (10**chainlink_decimals)
+    oracle_price = float(scale_price(oracle_answer, oracle_decimals))
+    chainlink_price = float(chainlink_reading.price)
 
     # --- Batch 2: checkpoint data (needs roundId from batch 1) -------------------------
     with client.batch_requests() as batch:
@@ -97,7 +92,7 @@ def main() -> None:
     effective_at = int(latest_checkpoint[1])
 
     _check_nav_monotonicity(oracle_round_id, checkpoint_responses, oracle_decimals)
-    _check_chainlink_monotonicity(chainlink_answer, chainlink_decimals)
+    _check_chainlink_monotonicity(chainlink_reading)
     _check_oracle_divergence(oracle_price, chainlink_price)
     _check_supply_change(total_supply_raw, oracle_price)
     _check_oracle_staleness(current_timestamp, effective_at)
@@ -175,7 +170,7 @@ def _check_oracle_divergence(oracle_price: float, chainlink_price: float) -> Non
         )
 
 
-def _check_chainlink_monotonicity(chainlink_answer: int, chainlink_decimals: int) -> None:
+def _check_chainlink_monotonicity(reading: FeedReading) -> None:
     """Alert if the Chainlink NAV feed decreases versus the last observed value."""
     previous_answer = get_last_value_for_key_from_file(CACHE_FILE, CACHE_KEY_CHAINLINK_NAV)
     try:
@@ -183,16 +178,16 @@ def _check_chainlink_monotonicity(chainlink_answer: int, chainlink_decimals: int
     except (TypeError, ValueError):
         previous_answer_int = 0
 
+    chainlink_answer = reading.round_data.answer
     if previous_answer_int > 0 and chainlink_answer < previous_answer_int:
-        previous_price = previous_answer_int / (10**chainlink_decimals)
-        current_price = chainlink_answer / (10**chainlink_decimals)
+        previous_price = scale_price(previous_answer_int, reading.decimals)
         decrease_pct = (previous_answer_int - chainlink_answer) / previous_answer_int * 100
         send_alert(
             Alert(
                 AlertSeverity.CRITICAL,
                 f"USTB Chainlink NAV DECREASED\n"
                 f"Previous: ${previous_price:.6f}\n"
-                f"Current: ${current_price:.6f}\n"
+                f"Current: ${reading.price:.6f}\n"
                 f"Decrease: {decrease_pct:.4f}%",
                 PROTOCOL,
             )

--- a/tests/test_chainlink.py
+++ b/tests/test_chainlink.py
@@ -1,11 +1,14 @@
 import unittest
 from decimal import Decimal
+from typing import Any, cast
 
 from utils.chainlink import (
     FeedReading,
     RoundData,
+    read_feeds,
     scale_price,
 )
+from utils.web3_wrapper import Web3Client
 
 
 def _round(
@@ -18,37 +21,126 @@ def _round(
     return RoundData(round_id, answer, started_at, updated_at, answered_in_round)
 
 
+class _FakeFeedFunctions:
+    def __init__(self, address: str) -> None:
+        self.address = address
+
+    def latestRoundData(self) -> tuple[str, str]:
+        return ("latestRoundData", self.address)
+
+    def decimals(self) -> tuple[str, str]:
+        return ("decimals", self.address)
+
+
+class _FakeContract:
+    def __init__(self, address: str) -> None:
+        self.functions = _FakeFeedFunctions(address)
+
+
+class _FakeBatch:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def __enter__(self) -> "_FakeBatch":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object,
+    ) -> None:
+        return None
+
+    def add(self, call: tuple[str, str]) -> None:
+        self.calls.append(call)
+
+
+class _FakeClient:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.contract_addresses: list[str] = []
+        self.batch = _FakeBatch()
+        self.executed_calls: list[tuple[str, str]] = []
+
+    def get_contract(self, address: str, _abi: Any) -> _FakeContract:
+        self.contract_addresses.append(address)
+        return _FakeContract(address)
+
+    def batch_requests(self) -> _FakeBatch:
+        return self.batch
+
+    def execute_batch(self, batch: _FakeBatch) -> list[Any]:
+        self.executed_calls = list(batch.calls)
+        return self.responses
+
+
 class TestScalePrice(unittest.TestCase):
-    def test_scales_by_decimals(self):
+    def test_scales_by_decimals(self) -> None:
         self.assertEqual(scale_price(100_000_000, 8), Decimal("1"))
 
-    def test_scales_fractional(self):
+    def test_scales_fractional(self) -> None:
         self.assertEqual(scale_price(99_960_043, 8), Decimal("0.99960043"))
 
-    def test_zero_decimals_raises(self):
+    def test_zero_decimals_raises(self) -> None:
         with self.assertRaises(ValueError):
             scale_price(1, 0)
 
-    def test_negative_decimals_raises(self):
+    def test_negative_decimals_raises(self) -> None:
         with self.assertRaises(ValueError):
             scale_price(1, -1)
 
 
 class TestRoundData(unittest.TestCase):
-    def test_from_tuple_decodes_fields(self):
+    def test_from_tuple_decodes_fields(self) -> None:
         rd = RoundData.from_tuple((10, 99_851_375, 900, 1_000, 10))
         self.assertEqual(rd.round_id, 10)
         self.assertEqual(rd.answer, 99_851_375)
         self.assertEqual(rd.updated_at, 1_000)
         self.assertEqual(rd.answered_in_round, 10)
 
-    def test_from_tuple_wrong_length_raises(self):
+    def test_from_tuple_wrong_length_raises(self) -> None:
         with self.assertRaises(ValueError):
             RoundData.from_tuple((1, 2, 3))
 
-    def test_feed_reading_price_uses_decimals(self):
+    def test_feed_reading_price_uses_decimals(self) -> None:
         reading = FeedReading(address="0xabc", round_data=_round(answer=605_044_986_7456), decimals=8)
         self.assertEqual(reading.price, scale_price(605_044_986_7456, 8))
+
+
+class TestReadFeeds(unittest.TestCase):
+    def test_reads_round_data_and_decimals_for_each_feed(self) -> None:
+        client = _FakeClient(
+            [
+                (10, 101_000_000, 900, 1_000, 10),
+                8,
+                (20, 202_000_000, 1_900, 2_000, 20),
+                8,
+            ]
+        )
+
+        readings = read_feeds(cast(Web3Client, client), ["0xFeedA", "0xFeedB"])
+
+        self.assertEqual(client.contract_addresses, ["0xFeedA", "0xFeedB"])
+        self.assertEqual(
+            client.executed_calls,
+            [
+                ("latestRoundData", "0xFeedA"),
+                ("decimals", "0xFeedA"),
+                ("latestRoundData", "0xFeedB"),
+                ("decimals", "0xFeedB"),
+            ],
+        )
+        self.assertEqual(readings["0xFeedA"].round_data.answer, 101_000_000)
+        self.assertEqual(readings["0xFeedA"].decimals, 8)
+        self.assertEqual(readings["0xFeedB"].round_data.updated_at, 2_000)
+        self.assertEqual(readings["0xFeedB"].price, Decimal("2.02"))
+
+    def test_empty_feed_list_returns_empty_mapping(self) -> None:
+        client = _FakeClient([])
+
+        self.assertEqual(read_feeds(cast(Web3Client, client), []), {})
+        self.assertEqual(client.executed_calls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor USTB Chainlink NAV reads to use `utils.chainlink.read_feeds`
- keep the existing raw-answer cache key and monotonicity alert behavior
- add focused tests for shared Chainlink feed batching/decoding

## Verification
- `uv run pytest tests/`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv audit --preview-features audit-command`

Closes #303