### PR TITLE
fix(wavey-gist): use new files-snapshot payload for create endpoint

### DIFF
--- a/tests/test_wavey_gist.py
+++ b/tests/test_wavey_gist.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
-from utils.wavey_gist import upload_to_gist
+from utils.wavey_gist import DEFAULT_GIST_TITLE, PRIMARY_FILE_NAME, upload_to_gist
 
 
 def _mock_response(*, post_json: dict | None = None) -> MagicMock:
@@ -32,7 +32,11 @@ class TestUploadToGist(unittest.TestCase):
 
         payload = mock_post.call_args[1]["json"]
         self.assertEqual(payload["title"], "Test")
-        self.assertEqual(payload["markdown"], "# Test\n\nSome **markdown**")
+        # Wavey Gist now expects a `files` snapshot — the legacy `markdown` field
+        # is rejected with HTTP 400. README.md is the preferred primary filename
+        # (https://gist.wavey.info/llms.txt).
+        self.assertNotIn("markdown", payload)
+        self.assertEqual(payload["files"][PRIMARY_FILE_NAME]["content"], "# Test\n\nSome **markdown**")
         self.assertEqual(mock_post.call_args[1]["headers"]["Authorization"], "Bearer test-key")
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
@@ -42,8 +46,8 @@ class TestUploadToGist(unittest.TestCase):
 
         upload_to_gist("Content only")
         payload = mock_post.call_args[1]["json"]
-        self.assertEqual(payload["title"], "Monitoring Details")
-        self.assertEqual(payload["markdown"], "Content only")
+        self.assertEqual(payload["title"], DEFAULT_GIST_TITLE)
+        self.assertEqual(payload["files"][PRIMARY_FILE_NAME]["content"], "Content only")
 
     @patch.dict("utils.wavey_gist.os.environ", {}, clear=True)
     @patch("utils.wavey_gist.requests.post")
@@ -55,6 +59,17 @@ class TestUploadToGist(unittest.TestCase):
     @patch("utils.wavey_gist.requests.post")
     def test_missing_url_returns_empty(self, mock_post: MagicMock) -> None:
         mock_post.return_value = _mock_response(post_json={"id": "abc123"})
+        self.assertEqual(upload_to_gist("x"), "")
+
+    @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})
+    @patch("utils.wavey_gist.requests.post")
+    def test_http_error_returns_empty(self, mock_post: MagicMock) -> None:
+        # E.g. the legacy `markdown` field — the API now rejects unknown fields
+        # with HTTP 400. The function must keep alerting and return "" so the
+        # caller can fall back to the in-Telegram summary.
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("400 Client Error")
+        mock_post.return_value = mock_response
         self.assertEqual(upload_to_gist("x"), "")
 
     @patch.dict("utils.wavey_gist.os.environ", {"WAVEY_GIST_API_KEY": "test-key"})

--- a/utils/wavey_gist.py
+++ b/utils/wavey_gist.py
@@ -10,6 +10,9 @@ logger = get_logger("utils.wavey_gist")
 
 WAVEY_GIST_API_URL = "https://api.wavey.info/api/v1/gists"
 DEFAULT_GIST_TITLE = "Monitoring Details"
+# Wavey Gist picks `README.md` as the primary file when present, so the rendered
+# page opens with our content. See https://gist.wavey.info/llms.txt.
+PRIMARY_FILE_NAME = "README.md"
 
 
 def upload_to_gist(content: str, title: str = "") -> str:
@@ -17,7 +20,8 @@ def upload_to_gist(content: str, title: str = "") -> str:
 
     Args:
         content: The markdown text to upload.
-        title: Optional title, prepended as a top-level markdown heading.
+        title: Optional title, prepended as a top-level markdown heading and used
+            as the gist's display title.
 
     Returns:
         The URL of the created gist, or an empty string on failure.
@@ -31,23 +35,30 @@ def upload_to_gist(content: str, title: str = "") -> str:
         return ""
 
     markdown = f"# {title}\n\n{content}" if title else content
+    # Wavey Gist's create endpoint now expects a `files` snapshot — the legacy
+    # `title` + `markdown` fields are rejected with HTTP 400. See
+    # https://gist.wavey.info/llms.txt.
+    payload: dict = {
+        "title": title or DEFAULT_GIST_TITLE,
+        "files": {PRIMARY_FILE_NAME: {"content": markdown}},
+    }
 
     try:
         response = requests.post(
             WAVEY_GIST_API_URL,
-            json={"title": title or DEFAULT_GIST_TITLE, "markdown": markdown},
+            json=payload,
             headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
             timeout=10,
         )
         response.raise_for_status()
-        payload = response.json()
+        body = response.json()
     except (requests.RequestException, ValueError) as e:
         logger.warning("Failed to upload to Wavey Gist: %s", e)
         return ""
 
-    url = payload.get("url", "")
+    url = body.get("url", "")
     if not url:
-        logger.warning("Wavey Gist response did not include a URL: %s", payload)
+        logger.warning("Wavey Gist response did not include a URL: %s", body)
         return ""
 
     logger.info("Uploaded gist to %s", url)


### PR DESCRIPTION
## Summary

`utils/wavey_gist.upload_to_gist` was posting the **legacy** payload shape (`{title, markdown}`) to Wavey Gist. The API now rejects unknown fields with **HTTP 400**:

> `Legacy gist fields are no longer supported. Send a files snapshot and include expected_snapshot_sha256 for updates.`

`raise_for_status()` turned the 400 into `requests.HTTPError`, which the existing `try/except (requests.RequestException, ValueError)` swallowed. The caller (`format_explanation_line` in `utils/llm/ai_explainer.py`) then fell through to `⚠️ Couldn't post full report` in the Telegram message. The Telegram **summary** still shipped — only the linked detail was lost.

This is the same payload that powers every AI report link in production (e.g. timelock alerts, governance-proposal walkthroughs). Whenever an explanation had a `detail` long enough to be sent to gist, the team got the warning instead of a working link.

## Reproduction (against the prod `WAVEY_GIST_API_KEY`)

```
POST https://api.wavey.info/api/v1/gists
{ "title": "test", "markdown": "# test\n\n..." }
→ 400 {"error":{"code":"invalid_request",
      "message":"Legacy gist fields are no longer supported. ..."}}
```

## Fix

Switch the create payload to the documented **files-snapshot** shape and put the report under `README.md` (the API's preferred primary filename, so the rendered page opens with the content):

```json
{
  "title": "AI Transaction Analysis",
  "files": { "README.md": { "content": "# AI Transaction Analysis\n\n..." } }
}
```

Response shape (`{url, id, primary_file, files, snapshot_sha256, ...}`) is otherwise compatible — only the request body needed to change.

**Live-validated** with the production key after the patch: `Status 201`, gist renders with the correct title and `README.md` as the primary file.

## Tests

- `test_successful_upload`: assert the legacy `markdown` field is gone and the content lives at `files[README.md].content`.
- `test_no_title_sends_raw_content`: reworked to match the new shape.
- `test_http_error_returns_empty` (new): covers the exact failure mode that triggered this incident — the function must keep alerting and return `""` so the in-Telegram summary still ships even when gist is down or its schema changes again.

All 7 `test_wavey_gist.py` cases pass; `ruff format` and `ruff check` clean.

## Backfill

Pushed a follow-up gist for the InfiniFi LongTimelock call (tx `0xf61f9e5af62d4ec67b8b6ef71524226236e5d30acb1945531181b4e497c765f3`) that surfaced this — see the `[Full details]` link posted in the original thread.