### PR TITLE
feat(morpho): route YV unwind liquidity alerts to the curation chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,12 @@ TELEGRAM_CHAT_ID_DEFAULT=your-default-chat-id
 # errors channel, and from there to the originating protocol's chat.
 # TELEGRAM_CHAT_ID_ENVIO=your-envio-chat-id
 
+# Internal curation chat — risk findings the curation team acts on (vault
+# rebalances, market cap changes) rather than announcements for a protocol's
+# public group. A standalone chat served by the DEFAULT bot; if unset, those
+# alerts keep going to the originating protocol's own chat.
+# TELEGRAM_CHAT_ID_CURATION=your-curation-chat-id
+
 # Protocol-specific Telegram settings (legacy per-protocol chats)
 TELEGRAM_BOT_TOKEN_AAVE=your-aave-bot-token
 TELEGRAM_CHAT_ID_AAVE=your-aave-chat-id

--- a/monitoring.yaml
+++ b/monitoring.yaml
@@ -285,7 +285,7 @@ protocols:
       - name: "Vault Risk Levels"
         description: "Weighted total risk score vs vault threshold"
       - name: "Low Liquidity"
-        description: "V1/V2 vault liquidity <1%; combined v1/v2 YV-collateral unwind liquidity vs collateral at risk"
+        description: "V1/V2 vault liquidity <1%; combined v1/v2 YV-collateral unwind liquidity vs collateral at risk (unwind alerts go to the internal curation chat)"
       - name: "V1 Governance"
         description: "Pending supply caps, market removals, timelock changes, guardian changes"
       - name: "V2 Governance"

--- a/protocols/morpho/README.md
+++ b/protocols/morpho/README.md
@@ -71,6 +71,8 @@ For vaults that are used as collateral in Yearn v3 strategies (YV collateral vau
 5. Sums collateral at risk per underlying asset group
 6. Sends alerts only if combined withdrawable liquidity is below total collateral at risk plus buffer
 
+**Routing:** unwind liquidity alerts go to the internal curation chat (`TELEGRAM_CHAT_ID_CURATION`), not the public morpho group — the fix is a curation decision (rebalance the vaults, adjust market caps). If that chat id is unset they fall back to the morpho group. Every other morpho alert is unaffected.
+
 This approach alerts on liquidation coverage risk instead of low liquidity as a percentage of all assets, which avoids noise when a vault group is highly utilized but still has enough liquidity to unwind risky positions.
 
 ### Vault Risk Level

--- a/protocols/morpho/markets.py
+++ b/protocols/morpho/markets.py
@@ -39,6 +39,7 @@ from protocols.morpho.risk import (
 from utils.alert import Alert, AlertSeverity, send_alert
 from utils.chains import Chain
 from utils.logger import get_logger
+from utils.telegram import CURATION_CHANNEL, resolve_channel
 
 # Configuration constants
 logger = get_logger(PROTOCOL)
@@ -533,7 +534,11 @@ def check_yv_collateral_market_liquidity(
             f"📊 Required with buffer: ${required_liquidity:,.2f} ({coverage:.2f}x coverage)\n"
             f"💹 Markets:\n{market_lines}\n"
         )
-        send_alert(Alert(AlertSeverity.HIGH, message, PROTOCOL))
+        # Unwind liquidity is a curation decision (rebalance the vaults, adjust the
+        # market caps), not something the public morpho group can act on — so it
+        # goes to the internal curation chat instead. `protocol` stays morpho so the
+        # emergency-withdrawal dispatch hook still sees it.
+        send_alert(Alert(AlertSeverity.HIGH, message, PROTOCOL, channel=resolve_channel(CURATION_CHANNEL, PROTOCOL)))
 
 
 def check_individual_liquidity_for_chain(chain: Chain, chain_vaults: List[Dict[str, Any]]) -> None:

--- a/tests/test_morpho_markets.py
+++ b/tests/test_morpho_markets.py
@@ -1,10 +1,12 @@
 """Behavior tests for Morpho v1/v2 market and liquidity monitoring."""
 
+import os
 import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 from protocols.morpho._shared import (
+    PROTOCOL,
     Asset,
     BadDebt,
     MarketMetrics,
@@ -17,6 +19,7 @@ from protocols.morpho.markets import (
     YV_COLLATERAL_AT_RISK_POINTS,
     YV_COLLATERAL_STABLE_PRICE_SHOCK,
     calculate_combined_metrics,
+    check_yv_collateral_market_liquidity,
     collect_yv_collateral_markets,
     fetch_configured_vaults,
     get_markets_collateral_at_risk_usd,
@@ -31,6 +34,7 @@ from protocols.morpho.markets_v2 import (
     score_market_allocations,
 )
 from utils.chains import Chain
+from utils.telegram import CURATION_CHANNEL
 
 
 def _sample_metrics(market_id: str, asset_address: str = "0x" + "22" * 20) -> MarketMetrics:
@@ -278,6 +282,53 @@ class TestMorphoCollateralLiquidity(unittest.TestCase):
         )
 
         self.assertEqual(result, {market_id: (market, liquidity_group)})
+
+    def _run_underfunded_unwind_check(self) -> Any:
+        """Run the YV unwind check on a market whose liquidity cannot cover it."""
+        market_id = "0x6691cdcadd5d23ac68d2c1cf54dc97ab8242d2a888230de411094480252c2ed3"
+        asset_address = "0x203a662b0bd271a6ed5a60edfbd04bfce608fd36"
+        market = {
+            "marketId": market_id,
+            "collateralAsset": {"symbol": "yvvbUSDT", "chain": {"id": Chain.KATANA.chain_id}},
+            "loanAsset": {"symbol": "vbUSDC"},
+            "lltv": str(int(0.86 * 1e18)),
+            "state": {"borrowAssetsUsd": 1_000_000},
+        }
+        liquidity_by_asset = {
+            asset_address: {
+                "asset_address": asset_address,
+                "asset_symbol": "vbUSDT",
+                "combined_liquidity": 425_077.48,
+                "vault_names": ["Gauntlet USDT", "Yearn OG USDT (V2)"],
+            }
+        }
+
+        with (
+            patch(
+                "protocols.morpho.markets.get_markets_collateral_at_risk_usd",
+                return_value={market_id: 516_853.61},
+            ),
+            patch("protocols.morpho.markets.send_alert") as send,
+        ):
+            check_yv_collateral_market_liquidity(Chain.KATANA, [market], liquidity_by_asset)
+
+        send.assert_called_once()
+        return send.call_args.args[0]
+
+    def test_unwind_alert_goes_to_curation_chat(self) -> None:
+        with patch.dict(os.environ, {"TELEGRAM_CHAT_ID_CURATION": "curation_chat_id"}):
+            alert = self._run_underfunded_unwind_check()
+
+        self.assertEqual(alert.channel, CURATION_CHANNEL)
+        # protocol stays morpho so the emergency-withdrawal dispatch hook still fires.
+        self.assertEqual(alert.protocol, PROTOCOL)
+        self.assertIn("Insufficient vbUSDT unwind liquidity", alert.message)
+
+    def test_unwind_alert_falls_back_to_morpho_chat_when_curation_unset(self) -> None:
+        with patch.dict(os.environ, {"TELEGRAM_CHAT_ID_CURATION": ""}):
+            alert = self._run_underfunded_unwind_check()
+
+        self.assertEqual(alert.channel, PROTOCOL)
 
     def test_combines_v1_and_v2_withdrawable_liquidity(self) -> None:
         vaults: list[dict[str, Any]] = [

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -29,6 +29,13 @@ ERROR_CHANNEL = "errors"
 # bot — no topic thread and no dedicated bot token.
 ENVIO_CHANNEL = "envio"
 
+# Channel key for internal curation alerts — risk findings that are acted on by
+# the curation team rather than announced in a protocol's public group. Destination
+# is a standalone chat, TELEGRAM_CHAT_ID_CURATION, served by the DEFAULT bot — no
+# topic thread and no dedicated bot token. Route with `resolve_channel` so an unset
+# chat id falls back to the protocol's own group instead of dropping the alert.
+CURATION_CHANNEL = "curation"
+
 # Matches `bot<digits>:<token>` in Telegram API URLs. Used to scrub the bot
 # token out of exception messages — `requests.HTTPError.__str__()` includes
 # the full URL, so without this the token leaks into any log or alert that
@@ -318,6 +325,21 @@ def _update_alert_delivery_safe(
 def _channel_configured(channel: str) -> bool:
     """Return True if a dedicated destination (topic or chat id) is set for a channel."""
     return bool(os.getenv(f"TELEGRAM_TOPIC_ID_{channel.upper()}") or os.getenv(f"TELEGRAM_CHAT_ID_{channel.upper()}"))
+
+
+def resolve_channel(channel: str, fallback: str) -> str:
+    """Return `channel` when its chat id is configured, else `fallback`.
+
+    Shared chats (curation, envio) are configured per deployment. Sending to one
+    whose `TELEGRAM_CHAT_ID_<CHANNEL>` is unset would drop the message with only a
+    log line, so callers route through here and keep landing in their own group
+    until the chat is configured.
+
+    Args:
+        channel: Preferred channel key, e.g. ``CURATION_CHANNEL``.
+        fallback: Channel to use when the preferred one has no chat id.
+    """
+    return channel if os.getenv(f"TELEGRAM_CHAT_ID_{channel.upper()}") else fallback
 
 
 def _send_labelled(message: str, protocol: str, channel: str, disable_notification: bool, source: str) -> None:


### PR DESCRIPTION
The "Insufficient <asset> unwind liquidity for YV collateral markets" alert is acted on by curation (rebalance the vaults, adjust market caps), not by the public morpho group — so it now goes to an internal curation chat.

```
🚨 ⚠️ Insufficient vbUSDT unwind liquidity for YV collateral markets on KATANA
🏦 Vaults: Gauntlet USDT, Yearn OG USDT (V2), Gauntlet USDT (V2)
💰 Withdrawable vbUSDT: $425,077.48
🔥 Total collateral at risk: $516,853.61
📊 Required with buffer: $646,067.02 (0.66x coverage)
💹 Markets:
- yvvbUSDT/vbUSDC: $516,853.61 at risk (2% shock, LLTV 86.0%)
```

## Setup

One new env var, a standalone chat served by the DEFAULT bot:

```
TELEGRAM_CHAT_ID_CURATION=your-curation-chat-id
```

**Until it's set on the runner, nothing changes** — `resolve_channel` falls back to the morpho group, so a missing env var can't silently drop the alert.

## Changes

- `utils/telegram.py` — new `CURATION_CHANNEL` and `resolve_channel(channel, fallback)`.
- `protocols/morpho/markets.py` — the unwind alert is sent with `channel=resolve_channel(CURATION_CHANNEL, PROTOCOL)`. Its `protocol` stays `morpho`, so the emergency-withdrawal dispatch hook still fires and alert records keep their origin.
- Docs: `.env.example`, `protocols/morpho/README.md`, `monitoring.yaml`.
- Tests: two cases in `tests/test_morpho_markets.py` covering the curation route and the morpho fallback.

## Scope

Only this alert moves. Every other morpho alert (bad debt, allocation, risk level, per-vault low liquidity) still goes to the morpho group.

## Testing

`ruff check`/`format` clean; full suite passes (717 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)